### PR TITLE
Added Xamarin.Forms iOS / Android support

### DIFF
--- a/FFImageLoading.Forms.Droid/CachedImageRenderer.cs
+++ b/FFImageLoading.Forms.Droid/CachedImageRenderer.cs
@@ -1,0 +1,162 @@
+﻿using Android.Widget;
+using System;
+using System.ComponentModel;
+using Xamarin.Forms;
+using Xamarin.Forms.Platform.Android;
+using FFImageLoading;
+using FFImageLoading.Work;
+using FFImageLoading.Forms.Droid;
+using FFImageLoading.Forms;
+using Android.Runtime;
+using FFImageLoading.Views;
+
+[assembly: ExportRenderer(typeof(CachedImage), typeof(CachedImageRenderer))]
+namespace FFImageLoading.Forms.Droid
+{
+	/// <summary>
+	/// CachedImage Implementation
+	/// </summary>
+	[Preserve(AllMembers=true)]
+	public class CachedImageRenderer : ViewRenderer<CachedImage, ImageViewAsync>
+	{
+		/// <summary>
+		/// Used for registration with dependency service
+		/// </summary>
+		public async static void Init()
+		{
+			var temp = DateTime.Now;
+		}
+
+		private bool isDisposed;
+
+		public CachedImageRenderer()
+		{
+			AutoPackage = false;
+		}
+
+		protected override void Dispose(bool disposing)
+		{
+			if (!isDisposed)
+			{
+				isDisposed = true;
+				base.Dispose(disposing);
+			}
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<CachedImage> e)
+		{
+			base.OnElementChanged(e);
+
+			if (e.OldElement == null)
+			{
+				CachedImageView nativeControl = new CachedImageView(Context);
+				SetNativeControl(nativeControl);
+			}
+
+			UpdateBitmap(e.OldElement);
+			UpdateAspect();
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+			if (e.PropertyName == Image.SourceProperty.PropertyName)
+			{
+				UpdateBitmap(null);
+			}
+			if (e.PropertyName == Image.AspectProperty.PropertyName)
+			{
+				UpdateAspect();
+			}
+		}
+
+		private void UpdateAspect()
+		{
+			if (Element.Aspect == Aspect.AspectFill)
+				Control.SetScaleType(ImageView.ScaleType.CenterCrop);
+
+			else if (Element.Aspect == Aspect.Fill)
+				Control.SetScaleType(ImageView.ScaleType.FitXy);
+
+			else 
+				Control.SetScaleType(ImageView.ScaleType.FitCenter);
+		}
+
+		private void UpdateBitmap(Image previous = null)
+		{
+			if (previous == null || !object.Equals(previous.Source, Element.Source))
+			{
+				Xamarin.Forms.ImageSource source = Element.Source;
+
+				((IElementController)Element).SetValueFromRenderer(CachedImage.IsLoadingPropertyKey, true);
+
+				CachedImageView formsImageView = Control as CachedImageView;
+				if (formsImageView != null)
+				{
+					formsImageView.SkipInvalidate();
+				}
+
+				if (Element != null && object.Equals(Element.Source, source) && !isDisposed)
+				{
+					TaskParameter imageLoader = null;
+
+					if (source is UriImageSource)
+					{
+						var urlSource = (UriImageSource)source;
+						imageLoader = ImageService.LoadUrl(urlSource.Uri.ToString(), Element.CacheDuration);
+					}
+					else if (source is FileImageSource)
+					{
+						var fileSource = (FileImageSource)source;
+						Control.SetImageDrawable(Context.Resources.GetDrawable(fileSource.File));
+						ImageLoadingFinished(Element);
+					}
+					else if (source == null)
+					{
+						Control.SetImageDrawable(null);
+						ImageLoadingFinished(Element);
+					}
+					else
+					{
+						throw new NotImplementedException("ImageSource type not supported");
+					}
+
+					if (imageLoader != null)
+					{
+						if ((int)Element.DownsampleHeight != 0 || (int)Element.DownsampleWidth != 0)
+						{
+							if (Element.DownsampleHeight > Element.DownsampleWidth)
+							{
+								imageLoader.DownSample(height: (int)Element.DownsampleWidth);
+							}
+							else
+							{
+								imageLoader.DownSample(width: (int)Element.DownsampleHeight);
+							}
+						}
+
+						if (Element.RetryCount > 0)
+						{
+							imageLoader.Retry(Element.RetryCount, Element.RetryDelay);
+						}
+							
+						imageLoader.TransparencyChannel = Element.TransparencyEnabled;
+
+						imageLoader.Finish((work) => ImageLoadingFinished(Element));
+						imageLoader.Into(Control);	
+					}
+				}
+			}
+		}
+
+		void ImageLoadingFinished(CachedImage element)
+		{
+			if (element != null && !isDisposed)
+			{
+				((IElementController)element).SetValueFromRenderer(CachedImage.IsLoadingPropertyKey, false);
+				((IVisualElementController)element).NativeSizeChanged();	
+			}
+		}
+	}
+}
+

--- a/FFImageLoading.Forms.Droid/CachedImageView.cs
+++ b/FFImageLoading.Forms.Droid/CachedImageView.cs
@@ -1,0 +1,32 @@
+﻿using System;
+using FFImageLoading.Views;
+using Android.Content;
+
+namespace FFImageLoading.Forms.Droid
+{
+	public class CachedImageView : ImageViewAsync
+	{
+		private bool skipInvalidate;
+
+		public CachedImageView(Context context) : base(context)
+		{
+		}
+
+		public override void Invalidate()
+		{
+			if (this.skipInvalidate)
+			{
+				this.skipInvalidate = false;
+				return;
+			}
+			base.Invalidate();
+		}
+
+		public void SkipInvalidate()
+		{
+			this.skipInvalidate = true;
+		}
+	}
+
+}
+

--- a/FFImageLoading.Forms.Droid/FFImageLoading.Forms.Droid.csproj
+++ b/FFImageLoading.Forms.Droid/FFImageLoading.Forms.Droid.csproj
@@ -1,0 +1,86 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{EFBA0AD7-5A72-4C68-AF49-83D382785DCF};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{7014FEB6-0338-4A47-B600-4A1B48127C5C}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>FFImageLoading.Forms.Droid</RootNamespace>
+    <MonoAndroidAssetsPrefix>Assets</MonoAndroidAssetsPrefix>
+    <MonoAndroidResourcePrefix>Resources</MonoAndroidResourcePrefix>
+    <AndroidResgenClass>Resource</AndroidResgenClass>
+    <AndroidResgenFile>Resources\Resource.designer.cs</AndroidResgenFile>
+    <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
+    <AssemblyName>FFImageLoading.Forms.Droid</AssemblyName>
+    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidLinkMode>None</AndroidLinkMode>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Mono.Android" />
+    <Reference Include="Xamarin.Android.Support.v4">
+      <HintPath>..\packages\Xamarin.Android.Support.v4.21.0.3.0\lib\MonoAndroid10\Xamarin.Android.Support.v4.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform.Android">
+      <HintPath>..\packages\Xamarin.Forms.1.4.4.6392\lib\MonoAndroid10\Xamarin.Forms.Platform.Android.dll</HintPath>
+    </Reference>
+    <Reference Include="FormsViewGroup">
+      <HintPath>..\packages\Xamarin.Forms.1.4.4.6392\lib\MonoAndroid10\FormsViewGroup.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Core">
+      <HintPath>..\packages\Xamarin.Forms.1.4.4.6392\lib\MonoAndroid10\Xamarin.Forms.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Xaml">
+      <HintPath>..\packages\Xamarin.Forms.1.4.4.6392\lib\MonoAndroid10\Xamarin.Forms.Xaml.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform">
+      <HintPath>..\packages\Xamarin.Forms.1.4.4.6392\lib\MonoAndroid10\Xamarin.Forms.Platform.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Resources\Resource.designer.cs" />
+    <Compile Include="CachedImageRenderer.cs" />
+    <Compile Include="CachedImageView.cs" />
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="Resources\AboutResources.txt" />
+    <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <AndroidResource Include="Resources\values\Strings.xml" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
+  <Import Project="..\packages\Xamarin.Forms.1.4.4.6392\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.1.4.4.6392\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
+  <ItemGroup>
+    <ProjectReference Include="..\FFImageLoading.Droid\FFImageLoading.Droid.csproj">
+      <Project>{74BF9402-3E13-4003-8923-BC20A1294CE2}</Project>
+      <Name>FFImageLoading.Droid</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\FFImageLoading.Forms\FFImageLoading.Forms.csproj">
+      <Project>{3D6C1F12-68D7-44C2-A7DE-8E7942627A01}</Project>
+      <Name>FFImageLoading.Forms</Name>
+    </ProjectReference>
+  </ItemGroup>
+</Project>

--- a/FFImageLoading.Forms.Droid/Resources/AboutResources.txt
+++ b/FFImageLoading.Forms.Droid/Resources/AboutResources.txt
@@ -1,0 +1,44 @@
+Images, layout descriptions, binary blobs and string dictionaries can be included 
+in your application as resource files.  Various Android APIs are designed to 
+operate on the resource IDs instead of dealing with images, strings or binary blobs 
+directly.
+
+For example, a sample Android app that contains a user interface layout (main.axml),
+an internationalization string table (strings.xml) and some icons (drawable-XXX/icon.png) 
+would keep its resources in the "Resources" directory of the application:
+
+Resources/
+    drawable/
+        icon.png
+
+    layout/
+        main.axml
+
+    values/
+        strings.xml
+
+In order to get the build system to recognize Android resources, set the build action to
+"AndroidResource".  The native Android APIs do not operate directly with filenames, but 
+instead operate on resource IDs.  When you compile an Android application that uses resources, 
+the build system will package the resources for distribution and generate a class called "R" 
+(this is an Android convention) that contains the tokens for each one of the resources 
+included. For example, for the above Resources layout, this is what the R class would expose:
+
+public class R {
+    public class drawable {
+        public const int icon = 0x123;
+    }
+
+    public class layout {
+        public const int main = 0x456;
+    }
+
+    public class strings {
+        public const int first_string = 0xabc;
+        public const int second_string = 0xbcd;
+    }
+}
+
+You would then use R.drawable.icon to reference the drawable/icon.png file, or R.layout.main 
+to reference the layout/main.axml file, or R.strings.first_string to reference the first 
+string in the dictionary file values/strings.xml.

--- a/FFImageLoading.Forms.Droid/Resources/values/Strings.xml
+++ b/FFImageLoading.Forms.Droid/Resources/values/Strings.xml
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<resources>
+	<string name="library_name">FFImageLoading.Forms.Droid</string>
+</resources>

--- a/FFImageLoading.Forms.Droid/packages.config
+++ b/FFImageLoading.Forms.Droid/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Xamarin.Android.Support.v4" version="21.0.3.0" targetFramework="MonoAndroid50" />
+  <package id="Xamarin.Forms" version="1.4.4.6392" targetFramework="MonoAndroid50" />
+  <package id="modernhttpclient" version="2.2.0" targetFramework="MonoAndroid44" />
+</packages>

--- a/FFImageLoading.Forms.Touch/CachedImageRenderer.cs
+++ b/FFImageLoading.Forms.Touch/CachedImageRenderer.cs
@@ -1,0 +1,170 @@
+﻿using CoreGraphics;
+using System;
+using System.ComponentModel;
+using UIKit;
+using Xamarin.Forms.Platform.iOS;
+using Xamarin.Forms;
+using FFImageLoading.Work;
+using FFImageLoading;
+using Foundation;
+
+namespace FFImageLoading.Forms.Touch
+{
+	/// <summary>
+	/// CachedImage Implementation
+	/// </summary>
+	[Preserve(AllMembers = true)]
+	public class CachedImageRenderer : ViewRenderer<CachedImage, UIImageView>
+	{
+		/// <summary>
+		/// Used for registration with dependency service
+		/// </summary>
+		public async static void Init()
+		{
+			var temp = DateTime.Now;
+		}
+
+		private bool isDisposed;
+
+		protected override void Dispose(bool disposing)
+		{
+			if (isDisposed)
+			{
+				return;
+			}
+
+			UIImage image;
+			if (disposing && base.Control != null && (image = base.Control.Image) != null)
+			{
+				image.Dispose();
+			}
+
+			isDisposed = true;
+			base.Dispose(disposing);
+		}
+
+		protected override void OnElementChanged(ElementChangedEventArgs<CachedImage> e)
+		{
+			if (Control == null)
+			{
+				SetNativeControl(new UIImageView(CGRect.Empty) {
+					ContentMode = UIViewContentMode.ScaleAspectFit,
+					ClipsToBounds = true
+				});
+			}
+			if (e.NewElement != null)
+			{
+				SetAspect();
+				SetImage(e.OldElement);
+				SetOpacity();
+			}
+			base.OnElementChanged(e);
+		}
+
+		protected override void OnElementPropertyChanged(object sender, PropertyChangedEventArgs e)
+		{
+			base.OnElementPropertyChanged(sender, e);
+
+			if (e.PropertyName == CachedImage.SourceProperty.PropertyName)
+			{
+				SetImage(null);
+			}
+			if (e.PropertyName == CachedImage.IsOpaqueProperty.PropertyName)
+			{
+				SetOpacity();
+			}
+			if (e.PropertyName == CachedImage.AspectProperty.PropertyName)
+			{
+				SetAspect();
+			}
+		}
+
+		private void SetAspect()
+		{
+			Control.ContentMode = Element.Aspect.ToUIViewContentMode();
+		}
+
+		private void SetOpacity()
+		{
+			Control.Opaque = Element.IsOpaque;
+		}
+
+		private void SetImage(CachedImage oldElement = null)
+		{
+			Xamarin.Forms.ImageSource source = base.Element.Source;
+			if (oldElement != null)
+			{
+				Xamarin.Forms.ImageSource source2 = oldElement.Source;
+				if (object.Equals(source2, source))
+				{
+					return;
+				}
+				if (source2 is FileImageSource && source is FileImageSource && ((FileImageSource)source2).File == ((FileImageSource)source).File)
+				{
+					return;
+				}
+			}
+
+			((IElementController)Element).SetValueFromRenderer(CachedImage.IsLoadingPropertyKey, true);
+
+			TaskParameter imageLoader = null;
+
+			if (source == null)
+			{
+				Control.Image = null;
+				ImageLoadingFinished(Element);
+			}
+			else if (source is UriImageSource)
+			{
+				var urlSource = (UriImageSource)source;
+				imageLoader = ImageService.LoadUrl(urlSource.Uri.ToString(), Element.CacheDuration);
+			}
+			else if (source is FileImageSource)
+			{
+				var fileSource = (FileImageSource)source;
+				Control.Image = UIImage.FromBundle(fileSource.File);
+				ImageLoadingFinished(Element);
+			}
+			else
+			{
+				throw new NotImplementedException("ImageSource type not supported");
+			}
+
+			if (imageLoader != null)
+			{
+				if ((int)Element.DownsampleHeight != 0 || (int)Element.DownsampleWidth != 0)
+				{
+					if (Element.DownsampleHeight > Element.DownsampleWidth)
+					{
+						imageLoader.DownSample(height: (int)Element.DownsampleWidth);
+					}
+					else
+					{
+						imageLoader.DownSample(width: (int)Element.DownsampleHeight);
+					}
+				}
+
+				if (Element.RetryCount > 0)
+				{
+					imageLoader.Retry(Element.RetryCount, Element.RetryDelay);
+				}
+					
+				imageLoader.TransparencyChannel = Element.TransparencyEnabled;
+
+				imageLoader.Finish((work) => ImageLoadingFinished(Element));
+				imageLoader.Into(Control);	
+			}	
+		}
+
+		void ImageLoadingFinished(CachedImage element)
+		{
+			if (element != null && !isDisposed)
+			{
+				((IElementController)element).SetValueFromRenderer(CachedImage.IsLoadingPropertyKey, false);
+				((IVisualElementController)element).NativeSizeChanged();
+			}
+		}
+
+	}
+}
+

--- a/FFImageLoading.Forms.Touch/FFImageLoading.Forms.Touch.csproj
+++ b/FFImageLoading.Forms.Touch/FFImageLoading.Forms.Touch.csproj
@@ -1,0 +1,71 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{FEACFBD2-3405-455C-9665-78FE426C6842};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{1E70A5AF-AAFA-4247-8AFE-39CDA73EBCEC}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>FFImageLoading.Forms.Touch</RootNamespace>
+    <IPhoneResourcePrefix>Resources</IPhoneResourcePrefix>
+    <AssemblyName>FFImageLoading.Forms.Touch</AssemblyName>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Reference Include="System" />
+    <Reference Include="System.Xml" />
+    <Reference Include="System.Core" />
+    <Reference Include="Xamarin.iOS" />
+    <Reference Include="Xamarin.Forms.Platform.iOS">
+      <HintPath>..\packages\Xamarin.Forms.1.4.4.6392\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Core">
+      <HintPath>..\packages\Xamarin.Forms.1.4.4.6392\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Xaml">
+      <HintPath>..\packages\Xamarin.Forms.1.4.4.6392\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform">
+      <HintPath>..\packages\Xamarin.Forms.1.4.4.6392\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Resources\" />
+  </ItemGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="CachedImageRenderer.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
+  <Import Project="..\packages\Xamarin.Forms.1.4.4.6392\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.1.4.4.6392\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
+  <ItemGroup>
+    <ProjectReference Include="..\FFImageLoading.Touch\FFImageLoading.Touch.csproj">
+      <Project>{1597F7D4-432C-4F26-B508-0F6FAF0B9711}</Project>
+      <Name>FFImageLoading.Touch</Name>
+    </ProjectReference>
+    <ProjectReference Include="..\FFImageLoading.Forms\FFImageLoading.Forms.csproj">
+      <Project>{3D6C1F12-68D7-44C2-A7DE-8E7942627A01}</Project>
+      <Name>FFImageLoading.Forms</Name>
+    </ProjectReference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+</Project>

--- a/FFImageLoading.Forms.Touch/Properties/AssemblyInfo.cs
+++ b/FFImageLoading.Forms.Touch/Properties/AssemblyInfo.cs
@@ -1,0 +1,27 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes.
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("FFImageLoading.Forms.Touch")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("Daniel Luberda")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly,
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]
+

--- a/FFImageLoading.Forms.Touch/packages.config
+++ b/FFImageLoading.Forms.Touch/packages.config
@@ -1,0 +1,6 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Xamarin.Forms" version="1.4.4.6392" targetFramework="xamarinios10" />
+  <package id="modernhttpclient" version="2.2.0" targetFramework="xamarinios10" />
+  <package id="WebP.Touch" version="1.0.0" targetFramework="xamarinios10" />
+</packages>

--- a/FFImageLoading.Forms/CachedImage.cs
+++ b/FFImageLoading.Forms/CachedImage.cs
@@ -1,0 +1,118 @@
+﻿using System;
+using Xamarin.Forms;
+
+namespace FFImageLoading.Forms
+{
+	/// <summary>
+	/// CachedImage - Xamarin.Forms image replacement with caching and downsampling capabilities
+	/// </summary>
+	public class CachedImage : Image
+	{
+		public static readonly BindablePropertyKey IsLoadingPropertyKey = BindableProperty.CreateReadOnly("IsLoading", typeof(bool), typeof(CachedImage), false, BindingMode.OneWayToSource, null, null, null, null, null);
+
+		public static readonly BindableProperty RetryCountProperty = BindableProperty.Create<CachedImage, int> (w => w.RetryCount, 0);
+
+		/// <summary>
+		/// If image loading fails automatically retry it a number of times, with a specific delay. Sets number of retries.
+		/// </summary>
+		public int RetryCount
+		{
+			get
+			{
+				return (int)GetValue(RetryCountProperty); 
+			}
+			set
+			{
+				SetValue(RetryCountProperty, value); 
+			}
+		}
+
+		public static readonly BindableProperty RetryDelayProperty = BindableProperty.Create<CachedImage, int> (w => w.RetryDelay, 250);
+
+		/// <summary>
+		/// If image loading fails automatically retry it a number of times, with a specific delay. Sets delay in milliseconds between each trial
+		/// </summary>
+		public int RetryDelay
+		{
+			get
+			{
+				return (int)GetValue(RetryDelayProperty); 
+			}
+			set
+			{
+				SetValue(RetryDelayProperty, value); 
+			}
+		}
+
+		public static readonly BindableProperty DownsampleWidthProperty = BindableProperty.Create<CachedImage, double> (w => w.DownsampleWidth, 0f);
+
+		/// <summary>
+		/// Reduce memory usage by downsampling the image. Aspect ratio will be kept even if width/height values are incorrect. 
+		/// Optional DownsampleWidth parameter, if value is higher than zero it will try to downsample to this width while keeping aspect ratio.
+		/// </summary>
+		public double DownsampleWidth
+		{
+			get
+			{
+				return (double)GetValue(DownsampleWidthProperty); 
+			}
+			set
+			{
+				SetValue(DownsampleWidthProperty, value); 
+			}
+		}
+
+		public static readonly BindableProperty DownsampleHeightProperty = BindableProperty.Create<CachedImage, double> (w => w.DownsampleHeight, 0f);
+
+		/// <summary>
+		/// Reduce memory usage by downsampling the image. Aspect ratio will be kept even if width/height values are incorrect. 
+		/// Optional DownsampleHeight parameter, if value is higher than zero it will try to downsample to this height while keeping aspect ratio.
+		/// </summary>
+		public double DownsampleHeight
+		{
+			get
+			{
+				return (double)GetValue(DownsampleHeightProperty); 
+			}
+			set
+			{
+				SetValue(DownsampleHeightProperty, value); 
+			}
+		}
+
+		public static readonly BindableProperty CacheDurationProperty = BindableProperty.Create<CachedImage, TimeSpan> (w => w.CacheDuration, TimeSpan.FromDays(90));
+
+		/// <summary>
+		/// How long the file will be cached on disk.
+		/// </summary>
+		public TimeSpan CacheDuration
+		{
+			get
+			{
+				return (TimeSpan)GetValue(CacheDurationProperty); 
+			}
+			set
+			{
+				SetValue(CacheDurationProperty, value); 
+			}
+		}
+
+		public static readonly BindableProperty TransparencyEnabledProperty = BindableProperty.Create<CachedImage, bool> (w => w.TransparencyEnabled, false);
+
+		/// <summary>
+		/// Indicates if the transparency channel should be loaded. By default this value comes from ImageService.Config.LoadWithTransparencyChannel.
+		/// </summary>
+		public bool TransparencyEnabled
+		{
+			get
+			{
+				return (bool)GetValue(TransparencyEnabledProperty); 
+			}
+			set
+			{
+				SetValue(TransparencyEnabledProperty, value); 
+			}
+		}
+	}
+}
+

--- a/FFImageLoading.Forms/FFImageLoading.Forms.csproj
+++ b/FFImageLoading.Forms/FFImageLoading.Forms.csproj
@@ -1,0 +1,52 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
+    <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
+    <ProjectTypeGuids>{786C830F-07A1-408B-BD7F-6EE04809D6DB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
+    <ProjectGuid>{3D6C1F12-68D7-44C2-A7DE-8E7942627A01}</ProjectGuid>
+    <OutputType>Library</OutputType>
+    <RootNamespace>FFImageLoading.Forms</RootNamespace>
+    <AssemblyName>FFImageLoading.Forms</AssemblyName>
+    <TargetFrameworkProfile>Profile78</TargetFrameworkProfile>
+    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
+    <DebugSymbols>true</DebugSymbols>
+    <DebugType>full</DebugType>
+    <Optimize>false</Optimize>
+    <OutputPath>bin\Debug</OutputPath>
+    <DefineConstants>DEBUG;</DefineConstants>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
+    <DebugType>full</DebugType>
+    <Optimize>true</Optimize>
+    <OutputPath>bin\Release</OutputPath>
+    <ErrorReport>prompt</ErrorReport>
+    <WarningLevel>4</WarningLevel>
+    <ConsolePause>false</ConsolePause>
+  </PropertyGroup>
+  <ItemGroup>
+    <Compile Include="Properties\AssemblyInfo.cs" />
+    <Compile Include="CachedImage.cs" />
+  </ItemGroup>
+  <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
+  <Import Project="..\packages\Xamarin.Forms.1.4.4.6392\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\packages\Xamarin.Forms.1.4.4.6392\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
+  <ItemGroup>
+    <Reference Include="Xamarin.Forms.Core">
+      <HintPath>..\packages\Xamarin.Forms.1.4.4.6392\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Xaml">
+      <HintPath>..\packages\Xamarin.Forms.1.4.4.6392\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform">
+      <HintPath>..\packages\Xamarin.Forms.1.4.4.6392\lib\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
+    </Reference>
+  </ItemGroup>
+  <ItemGroup>
+    <None Include="packages.config" />
+  </ItemGroup>
+</Project>

--- a/FFImageLoading.Forms/Properties/AssemblyInfo.cs
+++ b/FFImageLoading.Forms/Properties/AssemblyInfo.cs
@@ -1,0 +1,27 @@
+﻿using System.Reflection;
+using System.Runtime.CompilerServices;
+
+// Information about this assembly is defined by the following attributes.
+// Change them to the values specific to your project.
+
+[assembly: AssemblyTitle("FFImageLoading.Forms")]
+[assembly: AssemblyDescription("")]
+[assembly: AssemblyConfiguration("")]
+[assembly: AssemblyCompany("")]
+[assembly: AssemblyProduct("")]
+[assembly: AssemblyCopyright("Daniel Luberda")]
+[assembly: AssemblyTrademark("")]
+[assembly: AssemblyCulture("")]
+
+// The assembly version has the format "{Major}.{Minor}.{Build}.{Revision}".
+// The form "{Major}.{Minor}.*" will automatically update the build and revision,
+// and "{Major}.{Minor}.{Build}.*" will update just the revision.
+
+[assembly: AssemblyVersion("1.0.*")]
+
+// The following attributes are used to specify the signing key for the assembly,
+// if desired. See the Mono documentation for more information about signing.
+
+//[assembly: AssemblyDelaySign(false)]
+//[assembly: AssemblyKeyFile("")]
+

--- a/FFImageLoading.Forms/packages.config
+++ b/FFImageLoading.Forms/packages.config
@@ -1,0 +1,4 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Xamarin.Forms" version="1.4.4.6392" targetFramework="portable-net45+win+wp80+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10" />
+</packages>

--- a/FFImageLoading.sln
+++ b/FFImageLoading.sln
@@ -15,6 +15,12 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "samples", "samples", "{B48F
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "ImageLoading.Sample", "samples\ImageLoading.Sample\ImageLoading.Sample.csproj", "{F898A684-E9C1-4154-9F80-6037287233F5}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FFImageLoading.Forms", "FFImageLoading.Forms\FFImageLoading.Forms.csproj", "{3D6C1F12-68D7-44C2-A7DE-8E7942627A01}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FFImageLoading.Forms.Droid", "FFImageLoading.Forms.Droid\FFImageLoading.Forms.Droid.csproj", "{7014FEB6-0338-4A47-B600-4A1B48127C5C}"
+EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "FFImageLoading.Forms.Touch", "FFImageLoading.Forms.Touch\FFImageLoading.Forms.Touch.csproj", "{1E70A5AF-AAFA-4247-8AFE-39CDA73EBCEC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -25,10 +31,22 @@ Global
 		{1597F7D4-432C-4F26-B508-0F6FAF0B9711}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{1597F7D4-432C-4F26-B508-0F6FAF0B9711}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{1597F7D4-432C-4F26-B508-0F6FAF0B9711}.Release|Any CPU.Build.0 = Release|Any CPU
+		{1E70A5AF-AAFA-4247-8AFE-39CDA73EBCEC}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{1E70A5AF-AAFA-4247-8AFE-39CDA73EBCEC}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{1E70A5AF-AAFA-4247-8AFE-39CDA73EBCEC}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{1E70A5AF-AAFA-4247-8AFE-39CDA73EBCEC}.Release|Any CPU.Build.0 = Release|Any CPU
+		{3D6C1F12-68D7-44C2-A7DE-8E7942627A01}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{3D6C1F12-68D7-44C2-A7DE-8E7942627A01}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{3D6C1F12-68D7-44C2-A7DE-8E7942627A01}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{3D6C1F12-68D7-44C2-A7DE-8E7942627A01}.Release|Any CPU.Build.0 = Release|Any CPU
 		{51CA3BE2-DF00-4F49-8054-E5C776992B61}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{51CA3BE2-DF00-4F49-8054-E5C776992B61}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{51CA3BE2-DF00-4F49-8054-E5C776992B61}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{51CA3BE2-DF00-4F49-8054-E5C776992B61}.Release|Any CPU.Build.0 = Release|Any CPU
+		{7014FEB6-0338-4A47-B600-4A1B48127C5C}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{7014FEB6-0338-4A47-B600-4A1B48127C5C}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{7014FEB6-0338-4A47-B600-4A1B48127C5C}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{7014FEB6-0338-4A47-B600-4A1B48127C5C}.Release|Any CPU.Build.0 = Release|Any CPU
 		{74BF9402-3E13-4003-8923-BC20A1294CE2}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
 		{74BF9402-3E13-4003-8923-BC20A1294CE2}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{74BF9402-3E13-4003-8923-BC20A1294CE2}.Release|Any CPU.ActiveCfg = Release|Any CPU


### PR DESCRIPTION
Xamarin.Forms `Image` class replacement which uses FFImageLoading. 

You have to initialize it in you platform specific project after `Xamarin.Forms.Init` method:

`CachedImageRenderer.Init();`

*Please test iOS version (can't build it now).*