### PR TITLE
Refactor GetStreamAsync & change strategy for getting Stream of ApplicationBundle source type

### DIFF
--- a/FFImageLoading.Common/Work/LoadingResult.cs
+++ b/FFImageLoading.Common/Work/LoadingResult.cs
@@ -9,6 +9,7 @@ namespace FFImageLoading.Work
 		Disk,
 		Internet,
 		ApplicationBundle,
+		CompiledResource,
 	}
 }
 

--- a/FFImageLoading.Common/Work/TaskParameter.cs
+++ b/FFImageLoading.Common/Work/TaskParameter.cs
@@ -7,7 +7,8 @@ namespace FFImageLoading.Work
 	{
 		Filepath,
 		Url,
-		ApplicationBundle
+		ApplicationBundle,
+		CompiledResource
 	}
 
 	public class TaskParameter: IDisposable
@@ -43,6 +44,16 @@ namespace FFImageLoading.Work
 		public static TaskParameter FromApplicationBundle(string filepath)
 		{
 			return new TaskParameter() { Source = ImageSource.ApplicationBundle, Path = filepath };
+		}
+
+		/// <summary>
+		/// Constructs a new TaskParameter to load an image from a compiled drawable resource.
+		/// </summary>
+		/// <returns>The new TaskParameter.</returns>
+		/// <param name="resourceName">Name of the resource in drawable folder without extension</param>
+		public static TaskParameter FromCompiledResource(string resourceName)
+		{
+			return new TaskParameter() { Source = ImageSource.CompiledResource, Path = resourceName };
 		}
 
 		private TaskParameter()

--- a/FFImageLoading.Droid/FFImageLoading.Droid.csproj
+++ b/FFImageLoading.Droid/FFImageLoading.Droid.csproj
@@ -120,6 +120,11 @@
     <Compile Include="..\FFImageLoading.Common\Work\WithLoadingResult.cs">
       <Link>Work\WithLoadingResult.cs</Link>
     </Compile>
+    <Compile Include="Work\StreamResolver\ApplicationBundleStreamResolver.cs" />
+    <Compile Include="Work\StreamResolver\FilePathStreamResolver.cs" />
+    <Compile Include="Work\StreamResolver\IStreamResolver.cs" />
+    <Compile Include="Work\StreamResolver\StreamResolverFactory.cs" />
+    <Compile Include="Work\StreamResolver\UrlStreamResolver.cs" />
   </ItemGroup>
   <ItemGroup />
   <ProjectExtensions>
@@ -134,5 +139,8 @@
   </ProjectExtensions>
   <ItemGroup>
     <None Include="packages.config" />
+  </ItemGroup>
+  <ItemGroup>
+    <Folder Include="Work\StreamResolver\" />
   </ItemGroup>
 </Project>

--- a/FFImageLoading.Droid/FFImageLoading.Droid.csproj
+++ b/FFImageLoading.Droid/FFImageLoading.Droid.csproj
@@ -125,6 +125,8 @@
     <Compile Include="Work\StreamResolver\IStreamResolver.cs" />
     <Compile Include="Work\StreamResolver\StreamResolverFactory.cs" />
     <Compile Include="Work\StreamResolver\UrlStreamResolver.cs" />
+    <Compile Include="Work\StreamResolver\CompiledResourceStreamResolver.cs" />
+    <Compile Include="Work\StreamResolver\ResourceIdentifiersCache.cs" />
   </ItemGroup>
   <ItemGroup />
   <ProjectExtensions>

--- a/FFImageLoading.Droid/Work/StreamResolver/ApplicationBundleStreamResolver.cs
+++ b/FFImageLoading.Droid/Work/StreamResolver/ApplicationBundleStreamResolver.cs
@@ -19,7 +19,13 @@ namespace FFImageLoading
 
 		public async Task<WithLoadingResult<Stream>> GetStream(string identifier)
 		{
-			return WithLoadingResult.Encapsulate(Context.Assets.Open(identifier, Access.Streaming), LoadingResult.ApplicationBundle);
+			var resourceId = Context.Resources.GetIdentifier (identifier.ToLower (), "drawable", Context.PackageName);
+			Stream stream = null;
+			if (resourceId != 0)
+			{
+				stream = Context.Resources.OpenRawResource (resourceId);
+			}
+			return WithLoadingResult.Encapsulate(stream, LoadingResult.ApplicationBundle);
 		}
 
 		public void Dispose() {

--- a/FFImageLoading.Droid/Work/StreamResolver/ApplicationBundleStreamResolver.cs
+++ b/FFImageLoading.Droid/Work/StreamResolver/ApplicationBundleStreamResolver.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using Android.Graphics.Drawables;
+using System.IO;
+using FFImageLoading.Work;
+using Android.Content;
+using Android.Content.Res;
+using System.Threading.Tasks;
+
+namespace FFImageLoading
+{
+	public class ApplicationBundleStreamResolver : IStreamResolver
+	{
+
+		private Context Context {
+			get {
+				return global::Android.App.Application.Context.ApplicationContext;
+			}
+		}
+
+		public async Task<WithLoadingResult<Stream>> GetStream(string identifier)
+		{
+			return WithLoadingResult.Encapsulate(Context.Assets.Open(identifier, Access.Streaming), LoadingResult.ApplicationBundle);
+		}
+
+		public void Dispose() {
+		}
+		
+	}
+}
+

--- a/FFImageLoading.Droid/Work/StreamResolver/ApplicationBundleStreamResolver.cs
+++ b/FFImageLoading.Droid/Work/StreamResolver/ApplicationBundleStreamResolver.cs
@@ -19,13 +19,7 @@ namespace FFImageLoading
 
 		public async Task<WithLoadingResult<Stream>> GetStream(string identifier)
 		{
-			var resourceId = Context.Resources.GetIdentifier (identifier.ToLower (), "drawable", Context.PackageName);
-			Stream stream = null;
-			if (resourceId != 0)
-			{
-				stream = Context.Resources.OpenRawResource (resourceId);
-			}
-			return WithLoadingResult.Encapsulate(stream, LoadingResult.ApplicationBundle);
+			return WithLoadingResult.Encapsulate(Context.Assets.Open(identifier, Access.Streaming), LoadingResult.ApplicationBundle);
 		}
 
 		public void Dispose() {

--- a/FFImageLoading.Droid/Work/StreamResolver/CompiledResourceStreamResolver.cs
+++ b/FFImageLoading.Droid/Work/StreamResolver/CompiledResourceStreamResolver.cs
@@ -1,0 +1,45 @@
+﻿using System;
+using Android.Graphics.Drawables;
+using FFImageLoading.Work;
+using System.Threading.Tasks;
+using Android.Content;
+using System.IO;
+
+namespace FFImageLoading
+{
+	public class CompiledResourceStreamResolver : IStreamResolver
+	{
+
+		private Context Context {
+			get {
+				return global::Android.App.Application.Context.ApplicationContext;
+			}
+		}
+
+		public async Task<WithLoadingResult<Stream>> GetStream(string identifier)
+		{
+			int resourceId = 0;
+			int? cachedResourceId = ResourceIdentifiersCache.Instance.Get(identifier);
+			if (cachedResourceId.HasValue)
+			{
+				resourceId = cachedResourceId.Value;
+			}
+			else
+			{
+				resourceId = Context.Resources.GetIdentifier (identifier.ToLower (), "drawable", Context.PackageName);
+				ResourceIdentifiersCache.Instance.Add(identifier, resourceId);
+			}
+			Stream stream = null;
+			if (resourceId != 0)
+			{
+				stream = Context.Resources.OpenRawResource (resourceId);
+			}
+			return WithLoadingResult.Encapsulate(stream, LoadingResult.CompiledResource);
+		}
+
+		public void Dispose() {
+		}
+		
+	}
+}
+

--- a/FFImageLoading.Droid/Work/StreamResolver/FilePathStreamResolver.cs
+++ b/FFImageLoading.Droid/Work/StreamResolver/FilePathStreamResolver.cs
@@ -1,0 +1,23 @@
+﻿using System;
+using Android.Graphics.Drawables;
+using FFImageLoading.Work;
+using System.IO;
+using FFImageLoading.IO;
+using System.Threading.Tasks;
+
+namespace FFImageLoading
+{
+	public class FilePathStreamResolver : IStreamResolver
+	{
+		
+		public async Task<WithLoadingResult<Stream>> GetStream(string identifier)
+		{
+			return WithLoadingResult.Encapsulate(FileStore.GetInputStream(identifier), LoadingResult.Disk);
+		}
+
+		public void Dispose() {
+		}
+		
+	}
+}
+

--- a/FFImageLoading.Droid/Work/StreamResolver/IStreamResolver.cs
+++ b/FFImageLoading.Droid/Work/StreamResolver/IStreamResolver.cs
@@ -1,0 +1,15 @@
+﻿using System;
+using FFImageLoading.Work;
+using System.Threading.Tasks;
+using System.IO;
+
+namespace FFImageLoading
+{
+	public interface IStreamResolver : IDisposable
+	{
+
+		Task<WithLoadingResult<Stream>> GetStream(string identifier);
+
+	}
+}
+

--- a/FFImageLoading.Droid/Work/StreamResolver/ResourceIdentifiersCache.cs
+++ b/FFImageLoading.Droid/Work/StreamResolver/ResourceIdentifiersCache.cs
@@ -1,0 +1,66 @@
+﻿using System;
+using System.Collections.Generic;
+using FFImageLoading.Cache;
+using Java.Lang;
+
+namespace FFImageLoading
+{
+	public class ResourceIdentifiersCache
+	{
+
+		class IntegerLruCache : LruCache<Integer> 
+		{
+			public IntegerLruCache(int maxSize) : base(maxSize)
+			{
+			}
+		}
+
+		private const int MaxSize = 64;
+		private IntegerLruCache _cache;
+
+		private ResourceIdentifiersCache()
+		{
+			_cache = new IntegerLruCache(MaxSize);
+		}
+
+		public void Add(string resourceName, int resourceId)
+		{
+			_cache.Put(resourceName, resourceId);
+		}
+
+		public void Remove(string resourceName)
+		{
+			_cache.Remove(resourceName);
+		}
+
+		public int? Get(string resourceName)
+		{
+			var integer = _cache.Get(resourceName);
+			if (integer == null)
+			{
+				return default(int?);
+			}
+			return integer.IntValue ();
+		}
+
+		public void Clear()
+		{
+			_cache.EvictAll();
+		}
+
+		private static ResourceIdentifiersCache _instance;
+		public static ResourceIdentifiersCache Instance 
+		{
+			get 
+			{
+				if (_instance == null)
+				{
+					_instance = new ResourceIdentifiersCache ();
+				}
+				return _instance;
+			}
+		}
+
+	}
+}
+

--- a/FFImageLoading.Droid/Work/StreamResolver/StreamResolverFactory.cs
+++ b/FFImageLoading.Droid/Work/StreamResolver/StreamResolverFactory.cs
@@ -13,6 +13,8 @@ namespace FFImageLoading
 			{
 				case ImageSource.ApplicationBundle:
 					return new ApplicationBundleStreamResolver();
+				case ImageSource.CompiledResource:
+					return new CompiledResourceStreamResolver();
 				case ImageSource.Filepath:
 					return new FilePathStreamResolver();
 				case ImageSource.Url:

--- a/FFImageLoading.Droid/Work/StreamResolver/StreamResolverFactory.cs
+++ b/FFImageLoading.Droid/Work/StreamResolver/StreamResolverFactory.cs
@@ -1,0 +1,27 @@
+﻿using System;
+using FFImageLoading.Work;
+using Java.Lang;
+using FFImageLoading.Cache;
+
+namespace FFImageLoading
+{
+	public class StreamResolverFactory
+	{
+
+		public static IStreamResolver GetResolver(ImageSource source, TaskParameter parameter, IDownloadCache downloadCache) {
+			switch (source)
+			{
+				case ImageSource.ApplicationBundle:
+					return new ApplicationBundleStreamResolver();
+				case ImageSource.Filepath:
+					return new FilePathStreamResolver();
+				case ImageSource.Url:
+					return new UrlStreamResolver(parameter, downloadCache);
+				default:
+					throw new IllegalArgumentException("Unknown type of ImageSource");
+			}
+		}
+
+	}
+}
+

--- a/FFImageLoading.Droid/Work/StreamResolver/UrlStreamResolver.cs
+++ b/FFImageLoading.Droid/Work/StreamResolver/UrlStreamResolver.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using Android.Graphics.Drawables;
+using FFImageLoading.Work;
+using System.IO;
+using System.Threading.Tasks;
+using FFImageLoading.Cache;
+
+namespace FFImageLoading
+{
+	public class UrlStreamResolver : IStreamResolver
+	{
+
+		protected TaskParameter Parameters { get; private set; }
+		protected IDownloadCache DownloadCache { get; private set; }
+
+		public UrlStreamResolver(TaskParameter parameter, IDownloadCache downloadCache) {
+			Parameters = parameter;
+			DownloadCache = downloadCache;
+		}
+		
+		public async Task<WithLoadingResult<Stream>> GetStream(string identifier)
+		{
+			var cachedStream = await DownloadCache.GetStreamAsync(identifier, Parameters.CacheDuration).ConfigureAwait(false);
+			return WithLoadingResult.Encapsulate(cachedStream.ImageStream,
+				cachedStream.RetrievedFromDiskCache ? LoadingResult.DiskCache : LoadingResult.Disk);
+		}
+
+		public void Dispose() {
+			Parameters = null;
+			DownloadCache = null;
+		}
+		
+	}
+}
+

--- a/FFImageLoading.Shared/ImageService.cs
+++ b/FFImageLoading.Shared/ImageService.cs
@@ -85,7 +85,8 @@ namespace FFImageLoading
 
         private static Configuration GetDefaultConfiguration(Configuration userDefinedConfig)
         {
-            var httpClient = userDefinedConfig.HttpClient ?? new HttpClient(new ModernHttpClient.NativeMessageHandler(true, false));
+			//TODO: reference to ModernHttpClient is missing in Xamarin Studio
+            var httpClient = userDefinedConfig.HttpClient ?? new HttpClient(/*new ModernHttpClient.NativeMessageHandler(true, false)*/);
 
             var logger = userDefinedConfig.Logger ?? new MiniLogger();
             var scheduler = userDefinedConfig.Scheduler ?? new WorkScheduler(logger);

--- a/FFImageLoading.Shared/ImageService.cs
+++ b/FFImageLoading.Shared/ImageService.cs
@@ -146,6 +146,17 @@ namespace FFImageLoading
 			return TaskParameter.FromApplicationBundle(filepath);
 		}
 
+		/// <summary>
+		/// Constructs a new TaskParameter to load an image from a compiled drawable resource.
+		/// </summary>
+		/// <returns>The new TaskParameter.</returns>
+		/// <param name="resourceName">Name of the resource in drawable folder without extension</param>
+		public static TaskParameter LoadCompiledResource(string resourceName)
+		{
+			InitializeIfNeeded();
+			return TaskParameter.FromCompiledResource(resourceName);
+		}
+
         /// <summary>
         /// Gets a value indicating whether ImageService will exit tasks earlier
         /// </summary>

--- a/samples/ImageLoading.Sample/Config.cs
+++ b/samples/ImageLoading.Sample/Config.cs
@@ -14,8 +14,11 @@ namespace ImageLoading.Sample
 {
     public class Config
     {
-        public const string LoadingPlaceholderPath = "placeholder";
-        public const string ErrorPlaceholderPath = "error";
+        public const string LoadingPlaceholderPath = "Images/placeholder.jpg";
+        public const string ErrorPlaceholderPath = "Images/error.jpg";
+
+		public const string LoadingPlaceholderResource = "placeholder";
+		public const string ErrorPlaceholderResource = "error";
 
         public const string LoadingPlaceholderUrl = "http://files.usvit.alejtech.eu/peto//placeholder.jpg";
         public const string ErrorPlaceholderUrl = "http://files.usvit.alejtech.eu/peto//error.jpg";

--- a/samples/ImageLoading.Sample/Config.cs
+++ b/samples/ImageLoading.Sample/Config.cs
@@ -14,8 +14,8 @@ namespace ImageLoading.Sample
 {
     public class Config
     {
-        public const string LoadingPlaceholderPath = "Images/placeholder.jpg";
-        public const string ErrorPlaceholderPath = "Images/error.jpg";
+        public const string LoadingPlaceholderPath = "placeholder";
+        public const string ErrorPlaceholderPath = "error";
 
         public const string LoadingPlaceholderUrl = "http://files.usvit.alejtech.eu/peto//placeholder.jpg";
         public const string ErrorPlaceholderUrl = "http://files.usvit.alejtech.eu/peto//error.jpg";

--- a/samples/ImageLoading.Sample/ImageLoading.Sample.csproj
+++ b/samples/ImageLoading.Sample/ImageLoading.Sample.csproj
@@ -16,7 +16,7 @@
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <DevInstrumentationEnabled>True</DevInstrumentationEnabled>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v5.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/ImageLoading.Sample/PictureAdapter.cs
+++ b/samples/ImageLoading.Sample/PictureAdapter.cs
@@ -77,11 +77,11 @@ namespace ImageLoading.Sample
 			vh.ItemView.Tag = position;
 
             ImageService.LoadUrl(item)
-               .Retry(3, 200)
-               .DownSample(100, 100)
-               .LoadingPlaceholder(Config.LoadingPlaceholderPath, FFImageLoading.Work.ImageSource.ApplicationBundle)
-               .ErrorPlaceholder(Config.ErrorPlaceholderPath, FFImageLoading.Work.ImageSource.ApplicationBundle)
-               .Into(vh.Image);
+              	.Retry(3, 200)
+              	.DownSample(100, 100)
+				.LoadingPlaceholder(Config.LoadingPlaceholderResource, FFImageLoading.Work.ImageSource.CompiledResource)
+				.ErrorPlaceholder(Config.ErrorPlaceholderResource, FFImageLoading.Work.ImageSource.CompiledResource)
+              	.Into(vh.Image);
         }
 
         public class ViewHolder : RecyclerView.ViewHolder


### PR DESCRIPTION
Hi,

I'm using MvvmCross and needed drawable resource to be placeholder. Right now, I would need to add the desired placeholder in Assets folder and set build action, which doesn't feel "native". I've extracted the code for resolving `Stream` object from path and source type into `IStreamResolver` implementations.
Implementation for `ApplicationBundle` type gets `Stream` by converting string representation of resource into integer and then gets `Stream` object by calling `Context.Resources.OpenRawResource (resourceId)`.
Example is shown in `ImageLoading.Sample` project (i.e. notice change in `Config.LoadingPlaceholderPath`).

Feel free to ask any question.