### PR TITLE
Fixes and refactorings for Circle / Rounded Transformations

### DIFF
--- a/FFImageLoading.Transformations.Droid/CircleTransformation.cs
+++ b/FFImageLoading.Transformations.Droid/CircleTransformation.cs
@@ -17,8 +17,7 @@ namespace FFImageLoading.Transformations
 
 		protected override Bitmap Transform(Bitmap source)
 		{
-			int size = Math.Min(source.Width, source.Height);
-			return RoundedTransformation.ToRounded(source, size / 2);
+			return RoundedTransformation.ToRounded(source, 0f, 1f, 1f);
 		}
 	}
 }

--- a/FFImageLoading.Transformations.Droid/RoundedTransformation.cs
+++ b/FFImageLoading.Transformations.Droid/RoundedTransformation.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using FFImageLoading.Work;
 using Android.Graphics;
 
 namespace FFImageLoading.Transformations
@@ -7,46 +6,73 @@ namespace FFImageLoading.Transformations
 	public class RoundedTransformation : TransformationBase
 	{
 		private double _radius;
+		private double _cropWidthRatio;
+		private double _cropHeightRatio;
 
 		public RoundedTransformation(double radius)
 		{
 			_radius = radius;
+			_cropWidthRatio = 1f;
+			_cropHeightRatio = 1f;
+		}
+
+		public RoundedTransformation(double radius, double cropWidthRatio, double cropHeightRatio)
+		{
+			_radius = radius;
+			_cropWidthRatio = cropWidthRatio;
+			_cropHeightRatio = cropHeightRatio;
 		}
 
 		public override string Key
 		{
-			get { return string.Format("RoundedTransformation, radius = {0}", _radius); }
+			get { return string.Format("RoundedTransformation, radius = {0}, cropWidthRatio = {1}, cropHeightRatio = {2}", 
+				_radius, _cropWidthRatio, _cropHeightRatio); }
 		}
 			
 		protected override Bitmap Transform(Bitmap source)
 		{
-			return ToRounded(source, (float)_radius);
+			return ToRounded(source, (float)_radius, _cropWidthRatio, _cropHeightRatio);
 		}
 
-		public static Bitmap ToRounded(Bitmap source, float rad)
+		public static Bitmap ToRounded(Bitmap source, float rad, double cropWidthRatio, double cropHeightRatio)
 		{
-			int size = Math.Min(source.Width, source.Height);
+			double sourceWidth = source.Width;
+			double sourceHeight = source.Height;
 
-			int dx = (source.Width - size) / 2;
-			int dy = (source.Height - size) / 2;
+			double desiredWidth = sourceWidth;
+			double desiredHeight = sourceHeight;
 
-			Bitmap bitmap = Bitmap.CreateBitmap(size, size, Bitmap.Config.Argb8888);
+			double desiredRatio = cropWidthRatio / cropHeightRatio;
+			double currentRatio = sourceWidth / sourceHeight;
+
+			if (currentRatio > desiredRatio)
+				desiredWidth = (cropWidthRatio * sourceHeight / cropHeightRatio);
+			else if (currentRatio < desiredRatio)
+				desiredHeight = (cropHeightRatio * sourceWidth / cropWidthRatio);
+
+			float cropX = (float)((sourceWidth - desiredWidth) / 2);
+			float cropY = (float)((sourceHeight - desiredHeight) / 2);
+
+			if (rad == 0)
+				rad = (float)(Math.Min(desiredWidth, desiredHeight) / 2);
+
+			Bitmap bitmap = Bitmap.CreateBitmap((int)desiredWidth, (int)desiredHeight, Bitmap.Config.Argb8888);
 
 			using (Canvas canvas = new Canvas(bitmap))
 			using (Paint paint = new Paint())
 			using (BitmapShader shader = new BitmapShader(source, Shader.TileMode.Clamp, Shader.TileMode.Clamp))
 			using (Matrix matrix = new Matrix())
 			{
-				if (dx != 0 || dy != 0)
+				if (cropX != 0 || cropY != 0)
 				{
-					// source isn't square, move viewport to centre
-					matrix.SetTranslate(-dx, -dy);
+					matrix.SetTranslate(-cropX, -cropY);
 					shader.SetLocalMatrix(matrix);
 				}
+
 				paint.SetShader(shader);
 				paint.AntiAlias = true;
 
-				RectF rectF = new RectF(0, 0, size, size);
+				RectF rectF = new RectF(0, 0, (int)desiredWidth, (int)desiredHeight);
 				canvas.DrawRoundRect(rectF, rad, rad, paint);
 
 				return bitmap;				

--- a/FFImageLoading.Transformations.Touch/CircleTransformation.cs
+++ b/FFImageLoading.Transformations.Touch/CircleTransformation.cs
@@ -18,8 +18,7 @@ namespace FFImageLoading.Transformations
 
 		protected override UIImage Transform(UIImage source)
 		{
-			double size = Math.Min(source.Size.Width, source.Size.Height);
-			return RoundedTransformation.ToRounded(source, (nfloat)(size / 2));
+			return RoundedTransformation.ToRounded(source, 0f, 1f, 1f);
 		}
 	}
 }

--- a/FFImageLoading.Transformations.Touch/RoundedTransformation.cs
+++ b/FFImageLoading.Transformations.Touch/RoundedTransformation.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using FFImageLoading.Work;
 using UIKit;
 using CoreGraphics;
 
@@ -8,38 +7,76 @@ namespace FFImageLoading.Transformations
 	public class RoundedTransformation : TransformationBase
 	{
 		private double _radius;
+		private double _cropWidthRatio;
+		private double _cropHeightRatio;
 
 		public RoundedTransformation(double radius)
 		{
 			_radius = radius;
+			_cropWidthRatio = 1f;
+			_cropHeightRatio = 1f;
+		}
+
+		public RoundedTransformation(double radius, double cropWidthRatio, double cropHeightRatio)
+		{
+			_radius = radius;
+			_cropWidthRatio = cropWidthRatio;
+			_cropHeightRatio = cropHeightRatio;
 		}
 
 		public override string Key
 		{
-			get { return string.Format("RoundedTransformation, radius = {0}", _radius); }
+			get { return string.Format("RoundedTransformation, radius = {0}, cropWidthRatio = {1}, cropHeightRatio = {2}", 
+				_radius, _cropWidthRatio, _cropHeightRatio); }
 		}
 
 		protected override UIImage Transform(UIImage source)
 		{
-			return ToRounded(source, (nfloat)_radius);
+			return ToRounded(source, (nfloat)_radius, _cropWidthRatio, _cropHeightRatio);
 		}
 
-		public static UIImage ToRounded(UIImage source, nfloat rad)
+		public static UIImage ToRounded(UIImage source, nfloat rad, double cropWidthRatio, double cropHeightRatio)
 		{
-			nfloat size = (nfloat)Math.Min(source.Size.Width, source.Size.Height);
+			double sourceWidth = source.Size.Width;
+			double sourceHeight = source.Size.Height;
 
-			UIGraphics.BeginImageContextWithOptions(new CGSize(size, size), false, (nfloat)0.0);
+			double desiredWidth = sourceWidth;
+			double desiredHeight = sourceHeight;
+
+			double desiredRatio = cropWidthRatio / cropHeightRatio;
+			double currentRatio = sourceWidth / sourceHeight;
+
+			if (currentRatio > desiredRatio)
+				desiredWidth = (cropWidthRatio * sourceHeight / cropHeightRatio);
+			else if (currentRatio < desiredRatio)
+				desiredHeight = (cropHeightRatio * sourceWidth / cropWidthRatio);
+
+			float cropX = (float)((sourceWidth - desiredWidth) / 2);
+			float cropY = (float)((sourceHeight - desiredHeight) / 2);
+
+			if (rad == 0)
+				rad = (nfloat)(Math.Min(desiredWidth, desiredHeight) / 2);
+
+			UIGraphics.BeginImageContextWithOptions(new CGSize(desiredWidth, desiredHeight), false, (nfloat)0.0);
 
 			try
 			{
-				CGRect bounds = new CGRect(0, 0, size, size);
-
-				using (var path = UIBezierPath.FromRoundedRect(bounds, rad))			
+				using (var context = UIGraphics.GetCurrentContext())
 				{
-					path.AddClip();
-					source.Draw(bounds);
-					var newImage = UIGraphics.GetImageFromCurrentImageContext();
-					return newImage;
+					var clippedRect = new CGRect(0, 0, desiredWidth, desiredHeight);
+					context.BeginPath();
+
+					using (var path = UIBezierPath.FromRoundedRect(clippedRect, rad))
+					{
+						context.AddPath(path.CGPath);
+						context.Clip();
+					}
+
+					var drawRect = new CGRect(-cropX, -cropY, sourceWidth, sourceHeight);
+					source.Draw(drawRect);
+					var modifiedImage = UIGraphics.GetImageFromCurrentImageContext();
+
+					return modifiedImage;
 				}
 			}
 			finally

--- a/FFImageLoading.Transformations.nuspec
+++ b/FFImageLoading.Transformations.nuspec
@@ -4,7 +4,7 @@
        <id>Xamarin.FFImageLoading.Transformations</id>
        <version>1.1.7</version>
        <title>FFImageLoading image transformations</title>
-       <authors>Molinet Fabien</authors>
+       <authors>Molinet Fabien, Daniel Luberda</authors>
        <owners></owners>
        <licenseUrl>https://raw.githubusercontent.com/molinch/FFImageLoading/master/LICENSE.md</licenseUrl>
        <projectUrl>https://github.com/molinch/FFImageLoading</projectUrl>

--- a/FFImageLoading.Transformations/RoundedTransformation.cs
+++ b/FFImageLoading.Transformations/RoundedTransformation.cs
@@ -12,6 +12,11 @@ namespace FFImageLoading.Transformations
 			throw new Exception(DoNotReference);
 		}
 
+		public RoundedTransformation(double radius, double cropWidthRatio, double cropHeightRatio)
+		{
+			throw new Exception(DoNotReference);
+		}
+
 		public IBitmap Transform(IBitmap source)
 		{
 			throw new Exception(DoNotReference);


### PR DESCRIPTION
https://github.com/molinch/FFImageLoading/issues/62

- Unified behavior on both platforms (iOS/Android)
- `CircleTransformation` crops to rectangle by default
- `RoundedTransformation` crops to rectangle by default, but it can be changed (constructor with additional `cropWidthRatio` and `cropHeightRatio` parameters)