### PR TITLE
Various small improvements

### DIFF
--- a/FFImageLoading.Forms.Droid/CachedImageRenderer.cs
+++ b/FFImageLoading.Forms.Droid/CachedImageRenderer.cs
@@ -27,6 +27,7 @@ namespace FFImageLoading.Forms.Droid
 		}
 
 		private bool _isDisposed;
+		private IScheduledWork _currentTask;
 
 		public CachedImageRenderer()
 		{
@@ -50,8 +51,13 @@ namespace FFImageLoading.Forms.Droid
 			{
 				CachedImageView nativeControl = new CachedImageView(Context);
 				SetNativeControl(nativeControl);
+			} else {
+				e.OldElement.Cancelled -= Cancel;
 			}
-
+			if (e.NewElement != null)
+			{
+				e.NewElement.Cancelled += Cancel;
+			}
 			UpdateBitmap(e.OldElement);
 			UpdateAspect();
 		}
@@ -175,7 +181,7 @@ namespace FFImageLoading.Forms.Droid
 
 						imageLoader.Finish((work) => ImageLoadingFinished(Element));
 
-						imageLoader.Into(Control);	
+						_currentTask = imageLoader.Into(Control);	
 					}
 				}
 			}
@@ -187,6 +193,13 @@ namespace FFImageLoading.Forms.Droid
 			{
 				((IElementController)element).SetValueFromRenderer(CachedImage.IsLoadingPropertyKey, false);
 				((IVisualElementController)element).NativeSizeChanged();	
+			}
+		}
+
+		public void Cancel(object sender, EventArgs args)
+		{
+			if (_currentTask != null && !_currentTask.IsCancelled) {
+				_currentTask.Cancel ();
 			}
 		}
 	}

--- a/FFImageLoading.Forms.Touch/CachedImageRenderer.cs
+++ b/FFImageLoading.Forms.Touch/CachedImageRenderer.cs
@@ -21,6 +21,7 @@ namespace FFImageLoading.Forms.Touch
 	public class CachedImageRenderer : ViewRenderer<CachedImage, UIImageView>
 	{
 		private bool _isDisposed;
+		private IScheduledWork _currentTask;
 
 		/// <summary>
 		///   Used for registration with dependency service
@@ -57,11 +58,17 @@ namespace FFImageLoading.Forms.Touch
 					ClipsToBounds = true
 				});
 			}
+			if (e.OldElement != null)
+			{
+				e.OldElement.Cancelled -= Cancel;
+			}
 			if (e.NewElement != null)
 			{
 				SetAspect();
 				SetImage(e.OldElement);
 				SetOpacity();
+
+				e.NewElement.Cancelled += Cancel;
 			}
 			base.OnElementChanged(e);
 		}
@@ -190,7 +197,7 @@ namespace FFImageLoading.Forms.Touch
 				}
 
 				imageLoader.Finish((work) => ImageLoadingFinished(Element));
-				imageLoader.Into(Control);	
+				_currentTask = imageLoader.Into(Control);	
 			}
 		}
 
@@ -200,6 +207,13 @@ namespace FFImageLoading.Forms.Touch
 			{
 				((IElementController)element).SetValueFromRenderer(CachedImage.IsLoadingPropertyKey, false);
 				((IVisualElementController)element).NativeSizeChanged();
+			}
+		}
+
+		public void Cancel(object sender, EventArgs args)
+		{
+			if (_currentTask != null && !_currentTask.IsCancelled) {
+				_currentTask.Cancel ();
 			}
 		}
 

--- a/FFImageLoading.Forms/CachedImage.cs
+++ b/FFImageLoading.Forms/CachedImage.cs
@@ -367,6 +367,15 @@ namespace FFImageLoading.Forms
 			} 
 			return new SizeRequest(new Size(num3, num4));
 		}
+			
+		public event EventHandler Cancelled;
+
+		public void Cancel()
+		{
+			if (this.Cancelled != null) {
+				this.Cancelled (this, EventArgs.Empty);
+			}
+		}
 
 //		private void OnSourceChanged(object sender, EventArgs eventArgs)
 //		{

--- a/FFImageLoading.Touch/TaskParameterExtensions.cs
+++ b/FFImageLoading.Touch/TaskParameterExtensions.cs
@@ -5,6 +5,7 @@ using FFImageLoading.Work;
 using FFImageLoading.Helpers;
 using UIKit;
 using CoreAnimation;
+using FFImageLoading.Cache;
 
 
 namespace FFImageLoading
@@ -27,16 +28,15 @@ namespace FFImageLoading
                 return refView;
             };
 
-            Action<UIImage> doWithImage = img => {
+			Action<UIImage, bool> doWithImage = (img, fromCache) => {
                 UIImageView refView = getNativeControl();
                 if (refView == null)
                     return;
 
-
 				var isFadeAnimationEnabled = parameters.FadeAnimationEnabled.HasValue ? 
 					parameters.FadeAnimationEnabled.Value : ImageService.Config.FadeAnimationEnabled;
 
-				if (isFadeAnimationEnabled)
+				if (isFadeAnimationEnabled && !fromCache)
 				{
 					// fade animation
 					UIView.Transition(refView, 0.4f, UIViewAnimationOptions.TransitionCrossDissolve,
@@ -68,7 +68,7 @@ namespace FFImageLoading
                 return refView;
             };
 
-            Action<UIImage> doWithImage = img => {
+			Action<UIImage, bool> doWithImage = (img, fromCache) => {
                 UIButton refView = getNativeControl();
                 if (refView == null)
                     return;
@@ -101,7 +101,7 @@ namespace FFImageLoading
             return parameters.IntoAsync(param => param.Into(button, imageScale));
         }
 
-        private static IScheduledWork Into(this TaskParameter parameters, Func<UIView> getNativeControl, Action<UIImage> doWithImage, float imageScale = -1f)
+        private static IScheduledWork Into(this TaskParameter parameters, Func<UIView> getNativeControl, Action<UIImage, bool> doWithImage, float imageScale = -1f)
         {
             var task = new ImageLoaderTask(ImageService.Config.DownloadCache, new MainThreadDispatcher(), ImageService.Config.Logger, parameters,
                 getNativeControl, doWithImage, imageScale);

--- a/FFImageLoading.Touch/Work/ImageLoaderTask.cs
+++ b/FFImageLoading.Touch/Work/ImageLoaderTask.cs
@@ -14,7 +14,7 @@ namespace FFImageLoading.Work
 	public class ImageLoaderTask : ImageLoaderTaskBase
 	{
 		private readonly Func<UIView> _getNativeControl;
-		private readonly Action<UIImage> _doWithImage;
+		private readonly Action<UIImage, bool> _doWithImage;
 		private readonly nfloat _imageScale;
 
 		private static nfloat _screenScale;
@@ -24,7 +24,7 @@ namespace FFImageLoading.Work
 			_screenScale = UIScreen.MainScreen.Scale;
 		}
 
-		public ImageLoaderTask(IDownloadCache downloadCache, IMainThreadDispatcher mainThreadDispatcher, IMiniLogger miniLogger, TaskParameter parameters, Func<UIView> getNativeControl, Action<UIImage> doWithImage, nfloat imageScale)
+		public ImageLoaderTask(IDownloadCache downloadCache, IMainThreadDispatcher mainThreadDispatcher, IMiniLogger miniLogger, TaskParameter parameters, Func<UIView> getNativeControl, Action<UIImage, bool> doWithImage, nfloat imageScale)
 			: base(mainThreadDispatcher, miniLogger, parameters)
 		{
 			_getNativeControl = getNativeControl;
@@ -110,7 +110,7 @@ namespace FFImageLoading.Work
 						if (CancellationToken.IsCancellationRequested)
 							return;
 
-						_doWithImage(image);
+						_doWithImage(image, false);
 						Completed = true;
 						Parameters.OnSuccess(new ImageSize((int)image.Size.Width, (int)image.Size.Height), imageWithResult.Result);
 					}).ConfigureAwait(false);
@@ -145,6 +145,15 @@ namespace FFImageLoading.Work
 				if (nativeControl == null)
 					return CacheResult.NotFound; // weird situation, dunno what to do
 
+				if(Parameters.Source == ImageSource.ApplicationBundle) {
+					await MainThreadDispatcher.PostAsync(() =>
+						{
+							_doWithImage(UIImage.FromBundle(Parameters.Path), true);
+						}).ConfigureAwait(false);
+
+					return CacheResult.Found;
+				}
+
 	            var value = ImageCache.Instance.Get(GetKey());
 				if (value == null)
 					return CacheResult.NotFound; // not available in the cache
@@ -154,7 +163,7 @@ namespace FFImageLoading.Work
 
 				await MainThreadDispatcher.PostAsync(() =>
 					{
-						_doWithImage(value);
+						_doWithImage(value, true);
 					}).ConfigureAwait(false);
 
 				if (IsCancelled)
@@ -198,7 +207,8 @@ namespace FFImageLoading.Work
 			}
 			catch (Exception ex)
 			{
-				Logger.Error("Unable to retrieve image data", ex);
+				var message = String.Format("Unable to retrieve image data from source: {0}", sourcePath);
+				Logger.Error(message, ex);
 				Parameters.OnError(ex);
 				return null;
 			}
@@ -260,6 +270,20 @@ namespace FFImageLoading.Work
 			if (string.IsNullOrWhiteSpace(placeholderPath))
 				return false;
 
+			if (source == ImageSource.ApplicationBundle)
+			{
+				// Post on main thread but don't wait for it
+				MainThreadDispatcher.Post(() =>
+					{
+						if (CancellationToken.IsCancellationRequested)
+							return;
+
+						_doWithImage(UIImage.FromBundle(placeholderPath), true);
+					});
+
+				return true;
+			}
+
 			UIImage image = ImageCache.Instance.Get(GetKey(placeholderPath));
 			if (image == null)
 			{
@@ -291,7 +315,7 @@ namespace FFImageLoading.Work
 					if (CancellationToken.IsCancellationRequested)
 						return;
 				
-					_doWithImage(image);
+					_doWithImage(image, false);
 				});
 
 			return true;

--- a/samples/ImageLoading.Forms.Sample/Droid/FFImageLoading.Forms.Sample.Droid.csproj
+++ b/samples/ImageLoading.Forms.Sample/Droid/FFImageLoading.Forms.Sample.Droid.csproj
@@ -15,7 +15,7 @@
     <AndroidUseLatestPlatformSdk>True</AndroidUseLatestPlatformSdk>
     <AssemblyName>FFImageLoading.Forms.Sample.Droid</AssemblyName>
     <AndroidManifest>Properties\AndroidManifest.xml</AndroidManifest>
-    <TargetFrameworkVersion>v5.0</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v5.1</TargetFrameworkVersion>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>

--- a/samples/ImageLoading.Forms.Sample/Shared/FFImageLoading.Forms.Sample.csproj
+++ b/samples/ImageLoading.Forms.Sample/Shared/FFImageLoading.Forms.Sample.csproj
@@ -74,9 +74,6 @@
     <Reference Include="FFImageLoading">
       <HintPath>..\..\..\packages\Xamarin.FFImageLoading.1.1.7-alpha5\lib\portable-net45+win+wp80+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10\FFImageLoading.Transformations.dll</HintPath>
     </Reference>
-    <Reference Include="FFImageLoading">
-      <HintPath>..\..\..\packages\Xamarin.FFImageLoading.Forms.1.1.7-alpha5\lib\portable-net45+win+wp80+MonoTouch10+MonoAndroid10+xamarinmac20+xamarinios10\FFImageLoading.Forms.dll</HintPath>
-    </Reference>
     <ProjectReference Include="..\..\..\FFImageLoading.Forms\FFImageLoading.Forms.csproj">
       <Project>{3D6C1F12-68D7-44C2-A7DE-8E7942627A01}</Project>
       <Name>FFImageLoading.Forms</Name>

--- a/samples/ImageLoading.Forms.Sample/Shared/Pages/ListExamplePage.cs
+++ b/samples/ImageLoading.Forms.Sample/Shared/Pages/ListExamplePage.cs
@@ -4,6 +4,7 @@ using Xamarin.Forms;
 using FFImageLoading.Forms.Sample.ViewModels;
 using DLToolkit.PageFactory;
 using FFImageLoading.Forms.Sample.Models;
+using System.Diagnostics;
 
 namespace FFImageLoading.Forms.Sample.Pages
 {

--- a/samples/ImageLoading.Forms.Sample/iOS/FFImageLoading.Forms.Sample.iOS.csproj
+++ b/samples/ImageLoading.Forms.Sample/iOS/FFImageLoading.Forms.Sample.iOS.csproj
@@ -80,23 +80,23 @@
     <Reference Include="WebP.Touch">
       <HintPath>..\..\..\packages\WebP.Touch.1.0.1\lib\Xamarin.iOS10\WebP.Touch.dll</HintPath>
     </Reference>
-    <Reference Include="Xamarin.Forms.Platform.iOS">
-      <HintPath>..\..\..\packages\Xamarin.Forms.1.4.4.6392\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Forms.Core">
-      <HintPath>..\..\..\packages\Xamarin.Forms.1.4.4.6392\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Forms.Xaml">
-      <HintPath>..\..\..\packages\Xamarin.Forms.1.4.4.6392\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
-    </Reference>
-    <Reference Include="Xamarin.Forms.Platform">
-      <HintPath>..\..\..\packages\Xamarin.Forms.1.4.4.6392\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
-    </Reference>
     <Reference Include="DLToolkit.PageFactory.Shared">
       <HintPath>..\..\..\packages\DLToolkit.PageFactory.Shared.1.0.3\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\DLToolkit.PageFactory.Shared.dll</HintPath>
     </Reference>
     <Reference Include="DLToolkit.PageFactory.Forms">
       <HintPath>..\..\..\packages\DLToolkit.PageFactory.Forms.1.0.3\lib\portable-net45+wp8+wpa81+win8+MonoAndroid10+MonoTouch10+Xamarin.iOS10\DLToolkit.PageFactory.Forms.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform.iOS">
+      <HintPath>..\..\..\packages\Xamarin.Forms.1.5.0.6447\lib\Xamarin.iOS10\Xamarin.Forms.Platform.iOS.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Core">
+      <HintPath>..\..\..\packages\Xamarin.Forms.1.5.0.6447\lib\Xamarin.iOS10\Xamarin.Forms.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Xaml">
+      <HintPath>..\..\..\packages\Xamarin.Forms.1.5.0.6447\lib\Xamarin.iOS10\Xamarin.Forms.Xaml.dll</HintPath>
+    </Reference>
+    <Reference Include="Xamarin.Forms.Platform">
+      <HintPath>..\..\..\packages\Xamarin.Forms.1.5.0.6447\lib\Xamarin.iOS10\Xamarin.Forms.Platform.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -115,7 +115,7 @@
     <Compile Include="AppDelegate.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.iOS.CSharp.targets" />
-  <Import Project="..\..\..\packages\Xamarin.Forms.1.4.4.6392\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\..\..\packages\Xamarin.Forms.1.4.4.6392\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
+  <Import Project="..\..\..\packages\Xamarin.Forms.1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets" Condition="Exists('..\..\..\packages\Xamarin.Forms.1.5.0.6447\build\portable-win+net45+wp80+win81+wpa81+MonoAndroid10+MonoTouch10+Xamarin.iOS10\Xamarin.Forms.targets')" />
   <ItemGroup>
     <BundleResource Include="Resources\error.png" />
     <BundleResource Include="Resources\loading.png" />

--- a/samples/ImageLoading.Forms.Sample/iOS/packages.config
+++ b/samples/ImageLoading.Forms.Sample/iOS/packages.config
@@ -3,5 +3,5 @@
   <package id="DLToolkit.PageFactory.Forms" version="1.0.3" targetFramework="xamarinios10" />
   <package id="DLToolkit.PageFactory.Shared" version="1.0.3" targetFramework="xamarinios10" />
   <package id="WebP.Touch" version="1.0.1" targetFramework="xamarinios10" />
-  <package id="Xamarin.Forms" version="1.4.4.6392" targetFramework="xamarinios10" />
+  <package id="Xamarin.Forms" version="1.5.0.6447" targetFramework="xamarinios10" />
 </packages>


### PR DESCRIPTION
- Allow CachedImage to work as a drop-in replacement for the Xamarin.Forms.Image. In iOS, the bundled images are again correctly loading (synchronously) with the appropriate 1x, 2x or 3x version.
- Allow to Cancel pending download tasks, i.e. when a UITableViewCell has already left the screen before the download has finished.
- Only fade-in when image is not cached or loaded from a local resource.

The code changes were a bit quick and dirty, so feel free to refactor a bit! :)