### PR TITLE
Makes FFImageLoading linker-safe

### DIFF
--- a/FFImageLoading.MvvmCross/MvxCachedImageView.cs
+++ b/FFImageLoading.MvvmCross/MvxCachedImageView.cs
@@ -22,10 +22,8 @@ namespace FFImageLoading.Cross
 {
 
 #if __IOS__
-    [Preserve(AllMembers = true)]
     [Register("MvxCachedImageView")]
 #elif __ANDROID__
-    [Preserve(AllMembers = true)]
     [Register("ffimageloading.cross.MvxCachedImageView")]
 #endif
     /// <summary>

--- a/FFImageLoading.MvvmCross/MvxSvgCachedImageView.cs
+++ b/FFImageLoading.MvvmCross/MvxSvgCachedImageView.cs
@@ -22,10 +22,8 @@ using Android.Content;
 namespace FFImageLoading.Cross
 {
     #if __IOS__
-            [Preserve(AllMembers = true)]
             [Register("MvxSvgCachedImageView")]
     #elif __ANDROID__
-            [Preserve(AllMembers = true)]
             [Register("ffimageloading.cross.MvxSvgCachedImageView")]
     #endif
     /// <summary>

--- a/source/FFImageLoading.Common/Args/DownloadProgressEventArgs.cs
+++ b/source/FFImageLoading.Common/Args/DownloadProgressEventArgs.cs
@@ -2,7 +2,6 @@
 
 namespace FFImageLoading.Args
 {
-    [Preserve(AllMembers = true)]
     public class DownloadProgressEventArgs : EventArgs
     {
         public DownloadProgressEventArgs(DownloadProgress downloadProgress)

--- a/source/FFImageLoading.Common/Args/DownloadStartedEventArgs.cs
+++ b/source/FFImageLoading.Common/Args/DownloadStartedEventArgs.cs
@@ -2,7 +2,6 @@
 
 namespace FFImageLoading.Args
 {
-    [Preserve(AllMembers = true)]
     public class DownloadStartedEventArgs : EventArgs
     {
         public DownloadStartedEventArgs(DownloadInformation downloadInformation)

--- a/source/FFImageLoading.Common/Args/ErrorEventArgs.cs
+++ b/source/FFImageLoading.Common/Args/ErrorEventArgs.cs
@@ -2,7 +2,6 @@
 
 namespace FFImageLoading.Args
 {
-    [Preserve(AllMembers = true)]
     public class ErrorEventArgs : EventArgs
     {
         public ErrorEventArgs(Exception exception)

--- a/source/FFImageLoading.Common/Args/FileWriteFinishedEventArgs.cs
+++ b/source/FFImageLoading.Common/Args/FileWriteFinishedEventArgs.cs
@@ -2,7 +2,6 @@
 
 namespace FFImageLoading.Args
 {
-    [Preserve(AllMembers = true)]
     public class FileWriteFinishedEventArgs : EventArgs
     {
         public FileWriteFinishedEventArgs(FileWriteInfo fileWriteInfo)

--- a/source/FFImageLoading.Common/Args/FinishEventArgs.cs
+++ b/source/FFImageLoading.Common/Args/FinishEventArgs.cs
@@ -3,7 +3,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Args
 {
-    [Preserve(AllMembers = true)]
     public class FinishEventArgs : EventArgs
     {
         public FinishEventArgs(IScheduledWork scheduledWork)

--- a/source/FFImageLoading.Common/Args/SuccessEventArgs.cs
+++ b/source/FFImageLoading.Common/Args/SuccessEventArgs.cs
@@ -3,7 +3,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Args
 {
-    [Preserve(AllMembers = true)]
     public class SuccessEventArgs : EventArgs
     {
         public SuccessEventArgs(ImageInformation imageInformation, LoadingResult loadingResult)

--- a/source/FFImageLoading.Common/Cache/CacheResult.cs
+++ b/source/FFImageLoading.Common/Cache/CacheResult.cs
@@ -2,7 +2,6 @@
 
 namespace FFImageLoading.Cache
 {
-    [Preserve(AllMembers = true)]
 	public enum CacheResult
 	{
 		Found,

--- a/source/FFImageLoading.Common/Cache/CacheStream.cs
+++ b/source/FFImageLoading.Common/Cache/CacheStream.cs
@@ -3,7 +3,6 @@ using System.IO;
 
 namespace FFImageLoading.Cache
 {
-    [Preserve(AllMembers = true)]
 	public class CacheStream
 	{
         public CacheStream(Stream stream, bool retrievedFromDiskCache, string filePath)

--- a/source/FFImageLoading.Common/Cache/CacheType.cs
+++ b/source/FFImageLoading.Common/Cache/CacheType.cs
@@ -2,7 +2,6 @@
 
 namespace FFImageLoading.Cache
 {
-    [Preserve(AllMembers = true)]
     public enum CacheType
     {
         Memory,

--- a/source/FFImageLoading.Common/Cache/DownloadCache.cs
+++ b/source/FFImageLoading.Common/Cache/DownloadCache.cs
@@ -11,7 +11,6 @@ using FFImageLoading.Exceptions;
 
 namespace FFImageLoading.Cache
 {
-    [Preserve(AllMembers = true)]
     public class DownloadCache : IDownloadCache
     {
         public DownloadCache(Configuration configuration)

--- a/source/FFImageLoading.Common/Cache/IDiskCache.cs
+++ b/source/FFImageLoading.Common/Cache/IDiskCache.cs
@@ -4,7 +4,6 @@ using System.IO;
 
 namespace FFImageLoading.Cache
 {
-    [Preserve(AllMembers = true)]
     public interface IDiskCache
     {
         /// <summary>

--- a/source/FFImageLoading.Common/Cache/IDownloadCache.cs
+++ b/source/FFImageLoading.Common/Cache/IDownloadCache.cs
@@ -5,7 +5,6 @@ using FFImageLoading.Config;
 
 namespace FFImageLoading.Cache
 {
-    [Preserve(AllMembers = true)]
 	public interface IDownloadCache
 	{
         Task<CacheStream> DownloadAndCacheIfNeededAsync (string url, TaskParameter parameters, Configuration configuration, CancellationToken token);

--- a/source/FFImageLoading.Common/Cache/IMemoryCache.cs
+++ b/source/FFImageLoading.Common/Cache/IMemoryCache.cs
@@ -3,7 +3,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Cache
 {
-    [Preserve(AllMembers = true)]
 	public interface IMemoryCache<TImageContainer>
 	{
 		ImageInformation GetInfo(string key);

--- a/source/FFImageLoading.Common/Exceptions/DownloadAggregateException.cs
+++ b/source/FFImageLoading.Common/Exceptions/DownloadAggregateException.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 
 namespace FFImageLoading.Exceptions
 {
-    [Preserve(AllMembers = true)]
     public class DownloadAggregateException : AggregateException
     {
         public DownloadAggregateException()

--- a/source/FFImageLoading.Common/Exceptions/DownloadException.cs
+++ b/source/FFImageLoading.Common/Exceptions/DownloadException.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 namespace FFImageLoading.Exceptions
 {
-    [Preserve(AllMembers = true)]
     public class DownloadException : Exception
     { 
         public DownloadException(string message) : base(message)

--- a/source/FFImageLoading.Common/Exceptions/DownloadHeadersTimeoutException.cs
+++ b/source/FFImageLoading.Common/Exceptions/DownloadHeadersTimeoutException.cs
@@ -2,7 +2,6 @@
 
 namespace FFImageLoading.Exceptions
 {
-    [Preserve(AllMembers = true)]
     public class DownloadHeadersTimeoutException : Exception
     {
         public DownloadHeadersTimeoutException() : base("Headers timeout")

--- a/source/FFImageLoading.Common/Exceptions/DownloadHttpStatusCodeException.cs
+++ b/source/FFImageLoading.Common/Exceptions/DownloadHttpStatusCodeException.cs
@@ -3,7 +3,6 @@ using System.Net;
 
 namespace FFImageLoading.Exceptions
 {
-    [Preserve(AllMembers = true)]
     public class DownloadHttpStatusCodeException : Exception
     {
         public DownloadHttpStatusCodeException(HttpStatusCode httpStatusCode, string content = null) 

--- a/source/FFImageLoading.Common/Exceptions/DownloadReadTimeoutException.cs
+++ b/source/FFImageLoading.Common/Exceptions/DownloadReadTimeoutException.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 namespace FFImageLoading.Exceptions
 {
-    [Preserve(AllMembers = true)]
     public class DownloadReadTimeoutException : Exception
     {
         public DownloadReadTimeoutException() : base("Read timeout")

--- a/source/FFImageLoading.Common/Extensions/AssemblyExtensions.cs
+++ b/source/FFImageLoading.Common/Extensions/AssemblyExtensions.cs
@@ -3,7 +3,6 @@ using System.Reflection;
 
 namespace FFImageLoading
 {
-    [Preserve(AllMembers = true)]
     public static class AssemblyExtensions
     {
         public static string GetTypeAssemblyFullName(this Type type)

--- a/source/FFImageLoading.Common/Extensions/StringExtensions.cs
+++ b/source/FFImageLoading.Common/Extensions/StringExtensions.cs
@@ -3,7 +3,6 @@ using System.Linq;
 
 namespace FFImageLoading
 {
-    [Preserve(AllMembers = true)]
     public static class StringExtensions
     {
         public static string ToSanitizedKey(this string key)

--- a/source/FFImageLoading.Common/Helpers/IMD5Helper.cs
+++ b/source/FFImageLoading.Common/Helpers/IMD5Helper.cs
@@ -3,7 +3,6 @@ using System.IO;
 
 namespace FFImageLoading.Helpers
 {
-    [Preserve(AllMembers = true)]
     public interface IMD5Helper
     {
         string MD5(string input);

--- a/source/FFImageLoading.Common/Helpers/IMainThreadDispatcher.cs
+++ b/source/FFImageLoading.Common/Helpers/IMainThreadDispatcher.cs
@@ -3,7 +3,6 @@ using System.Threading.Tasks;
 
 namespace FFImageLoading.Helpers
 {
-    [Preserve(AllMembers = true)]
     public interface IMainThreadDispatcher
     {
         // void Post(Action action);

--- a/source/FFImageLoading.Common/Helpers/IMiniLogger.cs
+++ b/source/FFImageLoading.Common/Helpers/IMiniLogger.cs
@@ -3,7 +3,6 @@ using System.Diagnostics;
 
 namespace FFImageLoading.Helpers
 {
-    [Preserve(AllMembers = true)]
     public interface IMiniLogger
     {
         void Debug(string message);

--- a/source/FFImageLoading.Common/Helpers/IPlatformPerformance.cs
+++ b/source/FFImageLoading.Common/Helpers/IPlatformPerformance.cs
@@ -1,7 +1,6 @@
 ﻿using System;
 namespace FFImageLoading
 {
-    [Preserve(AllMembers = true)]
     public interface IPlatformPerformance
     {
         int GetCurrentManagedThreadId();

--- a/source/FFImageLoading.Common/Helpers/MiniLoggerWrapper.cs
+++ b/source/FFImageLoading.Common/Helpers/MiniLoggerWrapper.cs
@@ -2,7 +2,6 @@
 using FFImageLoading.Helpers;
 namespace FFImageLoading
 {
-    [Preserve(AllMembers = true)]
     internal class MiniLoggerWrapper : IMiniLogger
     {
         IMiniLogger _logger;

--- a/source/FFImageLoading.Common/Helpers/Retry.cs
+++ b/source/FFImageLoading.Common/Helpers/Retry.cs
@@ -5,7 +5,6 @@ using FFImageLoading.Exceptions;
 
 namespace FFImageLoading
 {
-    [Preserve(AllMembers = true)]
     public static class Retry
     {
         public static async Task<T> DoAsync<T>(Func<Task<T>> action, TimeSpan retryInterval, int retryCount, Action onRetry = null)

--- a/source/FFImageLoading.Common/Work/IImageLoaderTask.cs
+++ b/source/FFImageLoading.Common/Work/IImageLoaderTask.cs
@@ -5,7 +5,6 @@ using FFImageLoading.Config;
 
 namespace FFImageLoading.Work
 {
-    [Preserve(AllMembers = true)]
     public interface IImageLoaderTask : IScheduledWork, IDisposable
     {
         Task Init();

--- a/source/FFImageLoading.Common/Work/IImageService.cs
+++ b/source/FFImageLoading.Common/Work/IImageService.cs
@@ -16,7 +16,6 @@ namespace FFImageLoading
     /// <summary>
     /// FFImageLoading by Daniel Luberda
     /// </summary>
-    [Preserve(AllMembers = true)]
     public interface IImageService
     {
         /// <summary>

--- a/source/FFImageLoading.Droid/ImageService.cs
+++ b/source/FFImageLoading.Droid/ImageService.cs
@@ -13,7 +13,6 @@ namespace FFImageLoading
     /// <summary>
     /// FFImageLoading by Daniel Luberda
     /// </summary>
-    [Preserve(AllMembers = true)]
     public class ImageService : ImageServiceBase<SelfDisposingBitmapDrawable>
     {
         readonly Android.Util.DisplayMetrics _metrics = Android.Content.Res.Resources.System.DisplayMetrics;

--- a/source/FFImageLoading.Droid/Views/ImageViewAsync.cs
+++ b/source/FFImageLoading.Droid/Views/ImageViewAsync.cs
@@ -6,7 +6,6 @@ using Android.Widget;
 
 namespace FFImageLoading.Views
 {
-    [Preserve(AllMembers = true)]
     [Register("ffimageloading.views.ImageViewAsync")]
 	[Obsolete("You can now use Android's ImageView")]
     public class ImageViewAsync : ImageView

--- a/source/FFImageLoading.Forms.Droid/CachedImageFastRenderer.cs
+++ b/source/FFImageLoading.Forms.Droid/CachedImageFastRenderer.cs
@@ -25,7 +25,6 @@ namespace FFImageLoading.Forms.Platform
     /// <summary>
     /// CachedImage Implementation
     /// </summary>
-    [Preserve(AllMembers = true)]
     public class CachedImageFastRenderer : CachedImageView, IVisualElementRenderer
     {
         internal static readonly Type ElementRendererType = typeof(ImageRenderer).Assembly.GetType("Xamarin.Forms.Platform.Android.FastRenderers.VisualElementRenderer");

--- a/source/FFImageLoading.Forms.Droid/CachedImageRenderer.cs
+++ b/source/FFImageLoading.Forms.Droid/CachedImageRenderer.cs
@@ -23,7 +23,6 @@ namespace FFImageLoading.Forms.Platform
     /// <summary>
     /// CachedImage Implementation
     /// </summary>
-    [Preserve(AllMembers=true)]
     public class CachedImageRenderer : ViewRenderer<CachedImage, CachedImageView>
     {
         [RenderWith(typeof(CachedImageRenderer))]

--- a/source/FFImageLoading.Forms.Droid/CachedImageView.cs
+++ b/source/FFImageLoading.Forms.Droid/CachedImageView.cs
@@ -7,7 +7,6 @@ using Android.Widget;
 
 namespace FFImageLoading.Forms.Platform
 {
-    [Preserve(AllMembers = true)]
     public class CachedImageView : ImageView
     {
         bool _skipInvalidate;

--- a/source/FFImageLoading.Forms.Droid/FFImageLoadingImageViewHandler.cs
+++ b/source/FFImageLoading.Forms.Droid/FFImageLoadingImageViewHandler.cs
@@ -14,7 +14,6 @@ using Xamarin.Forms.Platform.Android;
 
 namespace FFImageLoading.Forms.Platform
 {
-	[Preserve(AllMembers = true)]
 	public class FFImageLoadingImageViewHandler : HandlerBase<ImageView>, IImageViewHandler
 	{
 		public Task LoadImageAsync(Xamarin.Forms.ImageSource imageSource, ImageView imageView, CancellationToken cancellationToken = default)

--- a/source/FFImageLoading.Forms.Droid/ImageSourceBinding.cs
+++ b/source/FFImageLoading.Forms.Droid/ImageSourceBinding.cs
@@ -7,7 +7,6 @@ using Android.Runtime;
 
 namespace FFImageLoading.Forms.Platform
 {
-    [Preserve(AllMembers = true)]
     internal class ImageSourceBinding : IImageSourceBinding
     {
         public ImageSourceBinding(FFImageLoading.Work.ImageSource imageSource, string path)

--- a/source/FFImageLoading.Forms.Tizen/ImageSourceBinding.cs
+++ b/source/FFImageLoading.Forms.Tizen/ImageSourceBinding.cs
@@ -6,7 +6,6 @@ using Xamarin.Forms;
 
 namespace FFImageLoading.Forms.Platform
 {
-    [Preserve(AllMembers = true)]
     internal class ImageSourceBinding : IImageSourceBinding
     {
         public ImageSourceBinding(FFImageLoading.Work.ImageSource imageSource, string path)

--- a/source/FFImageLoading.Forms.Touch/CachedImageRenderer.cs
+++ b/source/FFImageLoading.Forms.Touch/CachedImageRenderer.cs
@@ -32,7 +32,6 @@ namespace FFImageLoading.Forms.Platform
     /// <summary>
     /// CachedImage Implementation
     /// </summary>
-    [Preserve(AllMembers = true)]
     public class CachedImageRenderer : ViewRenderer<CachedImage, PImageView>
     {
         [RenderWith(typeof(CachedImageRenderer))]

--- a/source/FFImageLoading.Forms.Touch/ImageSourceBinding.cs
+++ b/source/FFImageLoading.Forms.Touch/ImageSourceBinding.cs
@@ -7,7 +7,6 @@ using Foundation;
 
 namespace FFImageLoading.Forms.Platform
 {
-    [Preserve(AllMembers= true)]
     internal class ImageSourceBinding : IImageSourceBinding
     {
         public ImageSourceBinding(FFImageLoading.Work.ImageSource imageSource, string path)

--- a/source/FFImageLoading.Forms.WinUWP/CachedImageRenderer.cs
+++ b/source/FFImageLoading.Forms.WinUWP/CachedImageRenderer.cs
@@ -36,7 +36,6 @@ namespace FFImageLoading.Forms.Platform
     /// <summary>
     /// CachedImage Implementation
     /// </summary>
-    [Preserve(AllMembers = true)]
     public class CachedImageRenderer : ViewRenderer<CachedImage, Windows.UI.Xaml.Controls.Image>
     {
         [RenderWith(typeof(CachedImageRenderer))]

--- a/source/FFImageLoading.Forms.Wpf/CachedImageRenderer.cs
+++ b/source/FFImageLoading.Forms.Wpf/CachedImageRenderer.cs
@@ -19,7 +19,6 @@ namespace FFImageLoading.Forms.Platform
 	/// <summary>
 	/// CachedImage Implementation
 	/// </summary>
-	[Preserve(AllMembers = true)]
 	public class CachedImageRenderer : ViewRenderer<CachedImage, Image>
     {
         [RenderWith(typeof(CachedImageRenderer))]

--- a/source/FFImageLoading.Forms/CachedImage.cs
+++ b/source/FFImageLoading.Forms/CachedImage.cs
@@ -9,7 +9,6 @@ using System.Reflection;
 
 namespace FFImageLoading.Forms
 {
-	[Preserve(AllMembers = true)]
 	[RenderWith(typeof(Platform.CachedImageRenderer._CachedImageRenderer))]
 	/// <summary>
 	/// CachedImage by Daniel Luberda

--- a/source/FFImageLoading.Forms/DataUrlImageSource.cs
+++ b/source/FFImageLoading.Forms/DataUrlImageSource.cs
@@ -3,7 +3,6 @@ using Xamarin.Forms;
 
 namespace FFImageLoading.Forms
 {
-    [Preserve(AllMembers = true)]
     public class DataUrlImageSource : ImageSource
     {
         public DataUrlImageSource(string dataUrl)

--- a/source/FFImageLoading.Forms/EmbeddedResourceImageSource.cs
+++ b/source/FFImageLoading.Forms/EmbeddedResourceImageSource.cs
@@ -9,7 +9,6 @@ namespace FFImageLoading.Forms
     /// eg. resource://YourProject.Resource.Resource.png
     /// eg. resource://YourProject.Resource.Resource.png?assembly=[FULL_ASSEMBLY_NAME]
     /// </summary>
-    [Preserve(AllMembers = true)]
     public class EmbeddedResourceImageSource : ImageSource
     {
         static string _cachedMainAssembly;

--- a/source/FFImageLoading.Forms/ICacheKeyFactory.cs
+++ b/source/FFImageLoading.Forms/ICacheKeyFactory.cs
@@ -3,7 +3,6 @@ using Xamarin.Forms;
 
 namespace FFImageLoading.Forms
 {
-    [Preserve(AllMembers = true)]
 	public interface ICacheKeyFactory
 	{
 		string GetKey(ImageSource imageSource, object bindingContext);

--- a/source/FFImageLoading.Forms/IImageSourceBinding.cs
+++ b/source/FFImageLoading.Forms/IImageSourceBinding.cs
@@ -6,7 +6,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Forms
 {
-    [Preserve(AllMembers = true)]
     public interface IImageSourceBinding
     {
         ImageSource ImageSource { get; }

--- a/source/FFImageLoading.Forms/IVectorImageSource.cs
+++ b/source/FFImageLoading.Forms/IVectorImageSource.cs
@@ -4,7 +4,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Forms
 {
-    [Preserve(AllMembers = true)]
 	public interface IVectorImageSource
 	{
 		IVectorDataResolver GetVectorDataResolver();

--- a/source/FFImageLoading.Forms/ImageSourceConverter.cs
+++ b/source/FFImageLoading.Forms/ImageSourceConverter.cs
@@ -4,7 +4,6 @@ using Xamarin.Forms;
 
 namespace FFImageLoading.Forms
 {
-    [Preserve(AllMembers = true)]
     public class ImageSourceConverter : TypeConverter, IValueConverter
     {
         public override bool CanConvertFrom(Type sourceType)

--- a/source/FFImageLoading.Mac/ImageService.cs
+++ b/source/FFImageLoading.Mac/ImageService.cs
@@ -13,7 +13,6 @@ namespace FFImageLoading
     /// <summary>
     /// FFImageLoading by Daniel Luberda
     /// </summary>
-    [Preserve(AllMembers = true)]
     public class ImageService : ImageServiceBase<NSImage>
     {
         static ConditionalWeakTable<object, IImageLoaderTask> _viewsReferences = new ConditionalWeakTable<object, IImageLoaderTask>();

--- a/source/FFImageLoading.Mock/ImageService.cs
+++ b/source/FFImageLoading.Mock/ImageService.cs
@@ -12,7 +12,6 @@ namespace FFImageLoading
     /// <summary>
     /// FFImageLoading by Daniel Luberda
     /// </summary>
-    [Preserve(AllMembers = true)]
     public class ImageService : ImageServiceBase<MockBitmap>
     {
         const string DoNotReference = "You are referencing the portable assembly - you need to reference the platform specific assembly";

--- a/source/FFImageLoading.Svg.Forms.Shared/SvgCachedImage.cs
+++ b/source/FFImageLoading.Svg.Forms.Shared/SvgCachedImage.cs
@@ -5,7 +5,6 @@ using Xamarin.Forms;
 
 namespace FFImageLoading.Svg.Forms
 {
-    [Preserve(AllMembers = true)]
     /// <summary>
     /// SvgCachedImage by Daniel Luberda
     /// </summary>

--- a/source/FFImageLoading.Svg.Forms.Shared/SvgImageSource.cs
+++ b/source/FFImageLoading.Svg.Forms.Shared/SvgImageSource.cs
@@ -8,7 +8,6 @@ using System.Collections.Generic;
 
 namespace FFImageLoading.Svg.Forms
 {
-    [Preserve(AllMembers = true)]
     /// <summary>
     /// SVG image source.
     /// </summary>

--- a/source/FFImageLoading.Svg.Forms.Shared/SvgImageSourceConverter.cs
+++ b/source/FFImageLoading.Svg.Forms.Shared/SvgImageSourceConverter.cs
@@ -5,7 +5,6 @@ using Xamarin.Forms;
 
 namespace FFImageLoading.Svg.Forms
 {
-    [Preserve(AllMembers = true)]
     /// <summary>
     /// SvgImageSourceConverter
     /// </summary>

--- a/source/FFImageLoading.Svg.Shared/SkSvg.cs
+++ b/source/FFImageLoading.Svg.Shared/SkSvg.cs
@@ -13,7 +13,6 @@ using System.Threading;
 
 namespace FFImageLoading.Svg.Platform
 {
-	[Preserve(AllMembers = true)]
 	public class SKSvg
 	{
 		private const float DefaultPPI = 160f;

--- a/source/FFImageLoading.Svg.Shared/SvgDataResolver.cs
+++ b/source/FFImageLoading.Svg.Shared/SvgDataResolver.cs
@@ -38,7 +38,6 @@ namespace FFImageLoading.Svg.Platform
     /// <summary>
     /// Svg data resolver.
     /// </summary>
-    [Preserve(AllMembers = true)]
     public class SvgDataResolver : IVectorDataResolver
     {
 #pragma warning disable RECS0108 // Warns about static fields in generic types

--- a/source/FFImageLoading.Svg/SvgDataResolver.cs
+++ b/source/FFImageLoading.Svg/SvgDataResolver.cs
@@ -8,7 +8,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Svg.Platform
 {
-    [Preserve(AllMembers=true)]
     public class SvgDataResolver : IVectorDataResolver
     {
         /// <summary>

--- a/source/FFImageLoading.Tizen/ImageService.cs
+++ b/source/FFImageLoading.Tizen/ImageService.cs
@@ -16,7 +16,6 @@ namespace FFImageLoading
     /// <summary>
     /// FFImageLoading for Tizen
     /// </summary>
-    [Preserve(AllMembers = true)]
     public class ImageService : ImageServiceBase<SharedEvasImage>
     {
         static ConditionalWeakTable<object, IImageLoaderTask> s_viewsReferences = new ConditionalWeakTable<object, IImageLoaderTask>();

--- a/source/FFImageLoading.Touch/ImageService.cs
+++ b/source/FFImageLoading.Touch/ImageService.cs
@@ -13,7 +13,6 @@ namespace FFImageLoading
     /// <summary>
     /// FFImageLoading by Daniel Luberda
     /// </summary>
-    [Preserve(AllMembers = true)]
     public class ImageService : ImageServiceBase<UIImage>
     {
         static ConditionalWeakTable<object, IImageLoaderTask> _viewsReferences = new ConditionalWeakTable<object, IImageLoaderTask>();

--- a/source/FFImageLoading.Transformations.Droid/BlurredTransformation.cs
+++ b/source/FFImageLoading.Transformations.Droid/BlurredTransformation.cs
@@ -5,7 +5,6 @@ using Android.Runtime;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class BlurredTransformation: TransformationBase
     {
         private Context _context;

--- a/source/FFImageLoading.Transformations.Droid/CircleTransformation.cs
+++ b/source/FFImageLoading.Transformations.Droid/CircleTransformation.cs
@@ -5,7 +5,6 @@ using Android.Runtime;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class CircleTransformation : TransformationBase
     {
         public CircleTransformation() : this(0d, null)

--- a/source/FFImageLoading.Transformations.Droid/ColorSpaceTransformation.cs
+++ b/source/FFImageLoading.Transformations.Droid/ColorSpaceTransformation.cs
@@ -5,7 +5,6 @@ using Android.Runtime;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class ColorSpaceTransformation : TransformationBase
     {
         ColorMatrix _colorMatrix;

--- a/source/FFImageLoading.Transformations.Droid/CornersTransformation.cs
+++ b/source/FFImageLoading.Transformations.Droid/CornersTransformation.cs
@@ -4,7 +4,6 @@ using Android.Runtime;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class CornersTransformation : TransformationBase
     {
         public CornersTransformation() : this(20d, CornerTransformType.TopRightRounded)

--- a/source/FFImageLoading.Transformations.Droid/CropTransformation.cs
+++ b/source/FFImageLoading.Transformations.Droid/CropTransformation.cs
@@ -3,7 +3,6 @@ using Android.Runtime;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class CropTransformation : TransformationBase
     {
         public CropTransformation() : this(1d, 0d, 0d)

--- a/source/FFImageLoading.Transformations.Droid/FlipTransformation.cs
+++ b/source/FFImageLoading.Transformations.Droid/FlipTransformation.cs
@@ -5,7 +5,6 @@ using Android.Util;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class FlipTransformation: TransformationBase
     {
         public FlipTransformation() : this(FlipType.Horizontal)

--- a/source/FFImageLoading.Transformations.Droid/GrayscaleTransformation.cs
+++ b/source/FFImageLoading.Transformations.Droid/GrayscaleTransformation.cs
@@ -3,7 +3,6 @@ using Android.Runtime;
 
 namespace FFImageLoading.Transformations
 {
-	[Preserve(AllMembers = true)]
 	public class GrayscaleTransformation : TransformationBase
 	{
 		public GrayscaleTransformation()

--- a/source/FFImageLoading.Transformations.Droid/RotateTransformation.cs
+++ b/source/FFImageLoading.Transformations.Droid/RotateTransformation.cs
@@ -4,7 +4,6 @@ using Android.Runtime;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class RotateTransformation : TransformationBase
     {
         public RotateTransformation() : this(30d)

--- a/source/FFImageLoading.Transformations.Droid/RoundedTransformation.cs
+++ b/source/FFImageLoading.Transformations.Droid/RoundedTransformation.cs
@@ -4,7 +4,6 @@ using Android.Runtime;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class RoundedTransformation : TransformationBase
     {
         public RoundedTransformation() : this(30d)

--- a/source/FFImageLoading.Transformations.Droid/SepiaTransformation.cs
+++ b/source/FFImageLoading.Transformations.Droid/SepiaTransformation.cs
@@ -3,7 +3,6 @@ using Android.Runtime;
 
 namespace FFImageLoading.Transformations
 {
-	[Preserve(AllMembers = true)]
 	public class SepiaTransformation : TransformationBase
 	{
 		public SepiaTransformation()

--- a/source/FFImageLoading.Transformations.Droid/TintTransformation.cs
+++ b/source/FFImageLoading.Transformations.Droid/TintTransformation.cs
@@ -4,7 +4,6 @@ using Android.Runtime;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class TintTransformation : ColorSpaceTransformation
     {
         public TintTransformation() : this(0, 165, 0, 128)

--- a/source/FFImageLoading.Transformations.Mac/BlurredTransformation.cs
+++ b/source/FFImageLoading.Transformations.Mac/BlurredTransformation.cs
@@ -5,7 +5,6 @@ using AppKit;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class BlurredTransformation : TransformationBase
     {
         public BlurredTransformation()

--- a/source/FFImageLoading.Transformations.Mac/CircleTransformation.cs
+++ b/source/FFImageLoading.Transformations.Mac/CircleTransformation.cs
@@ -3,7 +3,6 @@ using AppKit;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class CircleTransformation : TransformationBase
     {
         public CircleTransformation() : this(0d, null)

--- a/source/FFImageLoading.Transformations.Mac/ColorSpaceTransformation.cs
+++ b/source/FFImageLoading.Transformations.Mac/ColorSpaceTransformation.cs
@@ -7,7 +7,6 @@ using Foundation;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class ColorSpaceTransformation: TransformationBase
     {
         CGColorSpace _colorSpace;

--- a/source/FFImageLoading.Transformations.Mac/CornersTransformation.cs
+++ b/source/FFImageLoading.Transformations.Mac/CornersTransformation.cs
@@ -5,7 +5,6 @@ using Foundation;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class CornersTransformation : TransformationBase
     {
         public CornersTransformation() : this(20d, CornerTransformType.TopRightRounded)

--- a/source/FFImageLoading.Transformations.Mac/CropTransformation.cs
+++ b/source/FFImageLoading.Transformations.Mac/CropTransformation.cs
@@ -5,7 +5,6 @@ using Foundation;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class CropTransformation : TransformationBase
     {
         public CropTransformation() : this(1d, 0d, 0d)

--- a/source/FFImageLoading.Transformations.Mac/FlipTransformation.cs
+++ b/source/FFImageLoading.Transformations.Mac/FlipTransformation.cs
@@ -4,7 +4,6 @@ using AppKit;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class FlipTransformation: TransformationBase
     {
         public FlipTransformation() : this(FlipType.Horizontal)

--- a/source/FFImageLoading.Transformations.Mac/GrayscaleTransformation.cs
+++ b/source/FFImageLoading.Transformations.Mac/GrayscaleTransformation.cs
@@ -5,7 +5,6 @@ using AppKit;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class GrayscaleTransformation : TransformationBase
     {
         public GrayscaleTransformation()

--- a/source/FFImageLoading.Transformations.Mac/RotateTransformation.cs
+++ b/source/FFImageLoading.Transformations.Mac/RotateTransformation.cs
@@ -5,7 +5,6 @@ using Foundation;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class RotateTransformation : TransformationBase
     {
         public RotateTransformation() : this(30d)

--- a/source/FFImageLoading.Transformations.Mac/RoundedTransformation.cs
+++ b/source/FFImageLoading.Transformations.Mac/RoundedTransformation.cs
@@ -6,7 +6,6 @@ using FFImageLoading.Helpers;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class RoundedTransformation : TransformationBase
     {
         public RoundedTransformation() : this(30d)

--- a/source/FFImageLoading.Transformations.Mac/SepiaTransformation.cs
+++ b/source/FFImageLoading.Transformations.Mac/SepiaTransformation.cs
@@ -4,7 +4,6 @@ using Foundation;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class SepiaTransformation : TransformationBase
     {
         public SepiaTransformation()

--- a/source/FFImageLoading.Transformations.Mac/TintTransformation.cs
+++ b/source/FFImageLoading.Transformations.Mac/TintTransformation.cs
@@ -5,7 +5,6 @@ using AppKit;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class TintTransformation : ColorSpaceTransformation
     {
         public TintTransformation() : this(0, 165, 0, 128)

--- a/source/FFImageLoading.Transformations.Tizen/BlurredTransformation.cs
+++ b/source/FFImageLoading.Transformations.Tizen/BlurredTransformation.cs
@@ -2,7 +2,6 @@
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers=true)]
     public class BlurredTransformation : ITransformation
     {
         public BlurredTransformation()

--- a/source/FFImageLoading.Transformations.Tizen/CircleTransformation.cs
+++ b/source/FFImageLoading.Transformations.Tizen/CircleTransformation.cs
@@ -2,7 +2,6 @@
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class CircleTransformation : ITransformation
     {
         public CircleTransformation()

--- a/source/FFImageLoading.Transformations.Tizen/ColorSpaceTransformation.cs
+++ b/source/FFImageLoading.Transformations.Tizen/ColorSpaceTransformation.cs
@@ -3,7 +3,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class ColorSpaceTransformation: ITransformation
     {
         public ColorSpaceTransformation()

--- a/source/FFImageLoading.Transformations.Tizen/CornersTransformation.cs
+++ b/source/FFImageLoading.Transformations.Tizen/CornersTransformation.cs
@@ -2,7 +2,6 @@
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class CornersTransformation : ITransformation
     {
         public CornersTransformation() : this(20d, CornerTransformType.TopRightRounded)

--- a/source/FFImageLoading.Transformations.Tizen/CropTransformation.cs
+++ b/source/FFImageLoading.Transformations.Tizen/CropTransformation.cs
@@ -2,7 +2,6 @@
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class CropTransformation : ITransformation
     {
         public CropTransformation() : this(1d, 0d, 0d)

--- a/source/FFImageLoading.Transformations.Tizen/FlipTransformation.cs
+++ b/source/FFImageLoading.Transformations.Tizen/FlipTransformation.cs
@@ -2,7 +2,6 @@
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class FlipTransformation : ITransformation
     {
         public FlipTransformation() : this(FlipType.Horizontal)

--- a/source/FFImageLoading.Transformations.Tizen/GrayscaleTransformation.cs
+++ b/source/FFImageLoading.Transformations.Tizen/GrayscaleTransformation.cs
@@ -2,7 +2,6 @@
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class GrayscaleTransformation: ITransformation
     {
         public IBitmap Transform(IBitmap sourceBitmap, string path, ImageSource source, bool isPlaceholder, string key)

--- a/source/FFImageLoading.Transformations.Tizen/RotateTransformation.cs
+++ b/source/FFImageLoading.Transformations.Tizen/RotateTransformation.cs
@@ -2,7 +2,6 @@
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class RotateTransformation : ITransformation
     {
         public RotateTransformation() : this(30d)

--- a/source/FFImageLoading.Transformations.Tizen/RoundedTransformation.cs
+++ b/source/FFImageLoading.Transformations.Tizen/RoundedTransformation.cs
@@ -2,7 +2,6 @@
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class RoundedTransformation : ITransformation
     {
         public RoundedTransformation() : this(30d)

--- a/source/FFImageLoading.Transformations.Tizen/SepiaTransformation.cs
+++ b/source/FFImageLoading.Transformations.Tizen/SepiaTransformation.cs
@@ -2,7 +2,6 @@
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class SepiaTransformation : ITransformation
     {
         public IBitmap Transform(IBitmap sourceBitmap, string path, ImageSource source, bool isPlaceholder, string key)

--- a/source/FFImageLoading.Transformations.Tizen/TintTransformation.cs
+++ b/source/FFImageLoading.Transformations.Tizen/TintTransformation.cs
@@ -2,7 +2,6 @@
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class TintTransformation : ITransformation
     {
         public TintTransformation() : this(0, 165, 0, 128)

--- a/source/FFImageLoading.Transformations.Touch/BlurredTransformation.cs
+++ b/source/FFImageLoading.Transformations.Touch/BlurredTransformation.cs
@@ -5,7 +5,6 @@ using Foundation;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class BlurredTransformation : TransformationBase
     {
         public BlurredTransformation()

--- a/source/FFImageLoading.Transformations.Touch/CircleTransformation.cs
+++ b/source/FFImageLoading.Transformations.Touch/CircleTransformation.cs
@@ -3,7 +3,6 @@ using UIKit;
 
 namespace FFImageLoading.Transformations
 {
-	[Preserve(AllMembers = true)]
 	public class CircleTransformation : TransformationBase
 	{
 		public CircleTransformation() : this(0d, null)

--- a/source/FFImageLoading.Transformations.Touch/ColorSpaceTransformation.cs
+++ b/source/FFImageLoading.Transformations.Touch/ColorSpaceTransformation.cs
@@ -7,7 +7,6 @@ using Foundation;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class ColorSpaceTransformation: TransformationBase
     {
         CGColorSpace _colorSpace;

--- a/source/FFImageLoading.Transformations.Touch/CornersTransformation.cs
+++ b/source/FFImageLoading.Transformations.Touch/CornersTransformation.cs
@@ -5,7 +5,6 @@ using Foundation;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class CornersTransformation : TransformationBase
     {
         public CornersTransformation() : this(20d, CornerTransformType.TopRightRounded)

--- a/source/FFImageLoading.Transformations.Touch/CropTransformation.cs
+++ b/source/FFImageLoading.Transformations.Touch/CropTransformation.cs
@@ -5,7 +5,6 @@ using Foundation;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class CropTransformation : TransformationBase
     {
         public CropTransformation() : this(1d, 0d, 0d)

--- a/source/FFImageLoading.Transformations.Touch/FlipTransformation.cs
+++ b/source/FFImageLoading.Transformations.Touch/FlipTransformation.cs
@@ -4,7 +4,6 @@ using UIKit;
 
 namespace FFImageLoading.Transformations
 {
-	[Preserve(AllMembers = true)]
 	public class FlipTransformation: TransformationBase
 	{
 		public FlipTransformation() : this(FlipType.Horizontal)

--- a/source/FFImageLoading.Transformations.Touch/GrayscaleTransformation.cs
+++ b/source/FFImageLoading.Transformations.Touch/GrayscaleTransformation.cs
@@ -5,7 +5,6 @@ using UIKit;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class GrayscaleTransformation : TransformationBase
     {
         public GrayscaleTransformation()

--- a/source/FFImageLoading.Transformations.Touch/RotateTransformation.cs
+++ b/source/FFImageLoading.Transformations.Touch/RotateTransformation.cs
@@ -5,7 +5,6 @@ using Foundation;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class RotateTransformation : TransformationBase
     {
         public RotateTransformation() : this(30d)

--- a/source/FFImageLoading.Transformations.Touch/RoundedTransformation.cs
+++ b/source/FFImageLoading.Transformations.Touch/RoundedTransformation.cs
@@ -5,7 +5,6 @@ using Foundation;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class RoundedTransformation : TransformationBase
     {
         public RoundedTransformation() : this(30d)

--- a/source/FFImageLoading.Transformations.Touch/SepiaTransformation.cs
+++ b/source/FFImageLoading.Transformations.Touch/SepiaTransformation.cs
@@ -4,7 +4,6 @@ using Foundation;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class SepiaTransformation : TransformationBase
     {
         public SepiaTransformation()

--- a/source/FFImageLoading.Transformations.Touch/TintTransformation.cs
+++ b/source/FFImageLoading.Transformations.Touch/TintTransformation.cs
@@ -5,7 +5,6 @@ using UIKit;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class TintTransformation : ColorSpaceTransformation
     {
         public TintTransformation() : this(0, 165, 0, 128)

--- a/source/FFImageLoading.Transformations/BlurredTransformation.cs
+++ b/source/FFImageLoading.Transformations/BlurredTransformation.cs
@@ -3,7 +3,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers=true)]
 	public class BlurredTransformation : ITransformation
 	{
 		public BlurredTransformation()

--- a/source/FFImageLoading.Transformations/CircleTransformation.cs
+++ b/source/FFImageLoading.Transformations/CircleTransformation.cs
@@ -3,7 +3,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
 	public class CircleTransformation : ITransformation
 	{
 		public CircleTransformation()

--- a/source/FFImageLoading.Transformations/ColorSpaceTransformation.cs
+++ b/source/FFImageLoading.Transformations/ColorSpaceTransformation.cs
@@ -3,7 +3,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
 	public class ColorSpaceTransformation: ITransformation
 	{
 		public ColorSpaceTransformation()

--- a/source/FFImageLoading.Transformations/CornersTransformation.cs
+++ b/source/FFImageLoading.Transformations/CornersTransformation.cs
@@ -3,7 +3,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class CornersTransformation : ITransformation
     {
         public CornersTransformation()

--- a/source/FFImageLoading.Transformations/CropTransformation.cs
+++ b/source/FFImageLoading.Transformations/CropTransformation.cs
@@ -3,7 +3,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class CropTransformation : ITransformation
     {
         public CropTransformation()

--- a/source/FFImageLoading.Transformations/FlipTransformation.cs
+++ b/source/FFImageLoading.Transformations/FlipTransformation.cs
@@ -3,7 +3,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
 	public class FlipTransformation : ITransformation
 	{
 		public FlipTransformation()

--- a/source/FFImageLoading.Transformations/GrayscaleTransformation.cs
+++ b/source/FFImageLoading.Transformations/GrayscaleTransformation.cs
@@ -3,7 +3,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
 	public class GrayscaleTransformation: ITransformation
 	{
         public IBitmap Transform(IBitmap sourceBitmap, string path, ImageSource source, bool isPlaceholder, string key)

--- a/source/FFImageLoading.Transformations/RotateTransformation.cs
+++ b/source/FFImageLoading.Transformations/RotateTransformation.cs
@@ -3,7 +3,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class RotateTransformation : ITransformation
     {
         public RotateTransformation()

--- a/source/FFImageLoading.Transformations/RoundedTransformation.cs
+++ b/source/FFImageLoading.Transformations/RoundedTransformation.cs
@@ -3,7 +3,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
     public class RoundedTransformation : ITransformation
     {
         public RoundedTransformation()

--- a/source/FFImageLoading.Transformations/SepiaTransformation.cs
+++ b/source/FFImageLoading.Transformations/SepiaTransformation.cs
@@ -3,7 +3,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
 	public class SepiaTransformation : ITransformation
 	{
         public IBitmap Transform(IBitmap sourceBitmap, string path, ImageSource source, bool isPlaceholder, string key)

--- a/source/FFImageLoading.Transformations/TintTransformation.cs
+++ b/source/FFImageLoading.Transformations/TintTransformation.cs
@@ -3,7 +3,6 @@ using FFImageLoading.Work;
 
 namespace FFImageLoading.Transformations
 {
-    [Preserve(AllMembers = true)]
 	public class TintTransformation : ITransformation
 	{
 		public TintTransformation()

--- a/source/FFImageLoading.Windows/ImageService.cs
+++ b/source/FFImageLoading.Windows/ImageService.cs
@@ -15,7 +15,6 @@ namespace FFImageLoading
     /// <summary>
     /// FFImageLoading by Daniel Luberda
     /// </summary>
-    [Preserve(AllMembers = true)]
     public class ImageService : ImageServiceBase<BitmapSource>
     {
         static ConditionalWeakTable<object, IImageLoaderTask> _viewsReferences = new ConditionalWeakTable<object, IImageLoaderTask>();

--- a/source/FFImageLoading.Wpf/ImageService.cs
+++ b/source/FFImageLoading.Wpf/ImageService.cs
@@ -15,7 +15,6 @@ namespace FFImageLoading
     /// <summary>
     /// FFImageLoading by Daniel Luberda
     /// </summary>
-    //[Preserve(AllMembers = true)]
     public class ImageService : ImageServiceBase<BitmapSource>
     {
         static ConditionalWeakTable<object, IImageLoaderTask> _viewsReferences = new ConditionalWeakTable<object, IImageLoaderTask>();


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
Makes FFImageLoading linker-safe, so people can opt-in on what they want to bring as a dependency when using Linker configured as "Link All". This can help reduce app's sizes.

This closes #1317 

If anyone wants the old behavior and doesn't care about the app final size, they can just add rules to their `linker.xml`. Unfortunately, linker does not allow assembly wildcards ([AFAIK](https://github.com/mono/linker/blob/master/src/linker/Linker.Steps/ResolveFromXmlStep.cs)), so one rule must be used for each **different** assembly used, like this:

```xml
<linker>
       <!-- Other linker rules -->
        <assembly fullname="FFImageLoading.Forms">
                <type fullname="FFImageLoading*" preserve="all" />
        </assembly>
        <assembly fullname="FFImageLoading">
                <type fullname="FFImageLoading*" preserve="all" />
        </assembly>
</linker>
```

My suggestion is adding a new page to the wiki named "Linker configuration", with this info:

-----

If you are using Linker with "Link All" setting enabled, you might have to add rules to prevent Linker from removing types from FFImageLoading. Ideally you should preserve **just** what you are using, but if you prefer you can just add a catch-all rule to the Linker XML file as described in [Xamarin documentation](https://docs.microsoft.com/en-us/xamarin/cross-platform/deploy-test/linker), although it can result in an app with larger size than you need.

If you decide to just preserve everything, you must add a rule for each FFImageLoading assembly referenced by your project. Please remember that packages have dependencies, so for example, if you are using `FFImageLoading.Forms`, it has a dependency on `FFImageLoading` too, so you should add at least two rules, one for each assembly.

**Note:** If you add a rule for an assembly you are not using, the linker task will throw an error, so you should just add the ones you need:

```xml
<linker>
       <!-- Other linker rules -->

       <!-- Xamarin.FFImageLoading NuGet -->
        <assembly fullname="FFImageLoading">
                <type fullname="FFImageLoading*" preserve="all" />
        </assembly>
        <assembly fullname="FFImageLoading.Platform">
                <type fullname="FFImageLoading*" preserve="all" />
        </assembly>

        <!-- Xamarin.FFImageLoading.Forms NuGet -->
        <assembly fullname="FFImageLoading.Forms">
                <type fullname="FFImageLoading*" preserve="all" />
        </assembly>
        <assembly fullname="FFImageLoading.Forms.Platform">
                <type fullname="FFImageLoading*" preserve="all" />
        </assembly>

        <!-- Xamarin.FFImageLoading.Transformations NuGet -->
        <assembly fullname="FFImageLoading.Transformations">
                <type fullname="FFImageLoading*" preserve="all" />
        </assembly>

        <!-- Xamarin.FFImageLoading.Svg NuGet -->
        <assembly fullname="FFImageLoading.Svg.Platform">
                <type fullname="FFImageLoading*" preserve="all" />
        </assembly>

       <!-- Xamarin.FFImageLoading.Forms.Svg NuGet -->
        <assembly fullname="FFImageLoading.Svg.Forms">
                <type fullname="FFImageLoading*" preserve="all" />
        </assembly>
</linker>
```

------

### :arrow_heading_down: What is the current behavior?
FFImageLoading has `Preserve=All` for all classes, which makes impossible for someone to remove unused code to reduce app size.

### :new: What is the new behavior (if this is a feature change)?
FFImageLoading no longer preserves all, making it ok for Linker to remove anything that is unused, leading to a possibly smaller app size.

### :boom: Does this PR introduce a breaking change?
Yes, if someone is using "Link All", their app build _might_ break with this change alone, so they can just fix it adding only what they need or they can configure their linker as stated above to keep the old behavior.

### :bug: Recommendations for testing
Turn on "Link All", add the linker rules mentioned above and rebuild the samples.

### :memo: Links to relevant issues/docs
[Linker configuration](https://docs.microsoft.com/en-us/xamarin/cross-platform/deploy-test/linker)

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
