### PR TITLE
Adds support of implicit gradient offsets for SVGs

### DIFF
--- a/source/FFImageLoading.Svg.Shared/SkSvg.cs
+++ b/source/FFImageLoading.Svg.Shared/SkSvg.cs
@@ -1723,7 +1723,6 @@ namespace FFImageLoading.Svg.Platform
 		private SortedDictionary<float, SKColor> ReadStops(XElement e)
 		{
 			var stops = new SortedDictionary<float, SKColor>();
-			
 			var ns = e.Name.Namespace;
 			foreach (var se in e.Elements(ns + "stop"))
 			{

--- a/source/FFImageLoading.Svg.Shared/SkSvg.cs
+++ b/source/FFImageLoading.Svg.Shared/SkSvg.cs
@@ -1723,15 +1723,20 @@ namespace FFImageLoading.Svg.Platform
 		private SortedDictionary<float, SKColor> ReadStops(XElement e)
 		{
 			var stops = new SortedDictionary<float, SKColor>();
-
+			
 			var ns = e.Name.Namespace;
 			foreach (var se in e.Elements(ns + "stop"))
 			{
 				var style = ReadStyle(se);
 
-				var offset = ReadNumber(style["offset"]);
+				float offset = 0;
 				var color = SKColors.Black;
 				byte alpha = 255;
+
+				if (style.TryGetValue("offset", out string offsetValue))
+				{
+					offset = ReadNumber(offsetValue);
+				}
 
 				if (style.TryGetValue("stop-color", out string stopColor))
 				{


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
It's a small improvement, adding support of implicit gradient offsets by reading the property with a TryGetValue securely, when the offset is not in the dictionary.

### :arrow_heading_down: What is the current behavior?
On SVGs that don't have the `offset="0"` set explicitly the following exception happens:
```
System.Collections.Generic.KeyNotFoundException: The given key 'offset' was not present in the dictionary.
  at System.Collections.Generic.Dictionary`2[TKey,TValue].get_Item (TKey key) [0x0001e] in /Library/Frameworks/Xamarin.iOS.framework/Versions/Current/src/Xamarin.iOS/external/corefx/src/Common/src/CoreLib/System/Collections/Generic/Dictionary.cs:226 
  at FFImageLoading.Svg.Platform.SKSvg.ReadStops (System.Xml.Linq.XElement e) [0x0003e] in C:\projects\ffimageloading\source\FFImageLoading.Svg.Shared\SkSvg.cs:1732 
  at FFImageLoading.Svg.Platform.SKSvg.ReadLinearGradient (System.Xml.Linq.XElement e) [0x00081] in C:\projects\ffimageloading\source\FFImageLoading.Svg.Shared\SkSvg.cs:1668 
  at FFImageLoading.Svg.Platform.SKSvg.ReadPaints (System.Collections.Generic.Dictionary`2[TKey,TValue] style, SkiaSharp.SKPaint& strokePaint, SkiaSharp.SKPaint& fillPaint, System.Boolean isGroup, System.String& fillId, System.String& strokeFillId) [0x0050e] in C:\projects\ffimageloading\source\FFImageLoading.Svg.Shared\SkSvg.cs:1344 
  at FFImageLoading.Svg.Platform.SKSvg.ReadPaints (System.Xml.Linq.XElement e, SkiaSharp.SKPaint& stroke, SkiaSharp.SKPaint& fill, System.Boolean isGroup, System.Boolean isMask) [0x00008] in C:\projects\ffimageloading\source\FFImageLoading.Svg.Shared\SkSvg.cs:1148 
  at FFImageLoading.Svg.Platform.SKSvg.ReadElement (System.Xml.Linq.XElement e, SkiaSharp.SKCanvas canvas, SkiaSharp.SKPaint stroke, SkiaSharp.SKPaint fill, System.Boolean isMask, System.Threading.CancellationToken token) [0x00048] in C:\projects\ffimageloading\source\FFImageLoading.Svg.Shared\SkSvg.cs:237 
  at FFImageLoading.Svg.Platform.SKSvg.LoadElements (System.Collections.Generic.IEnumerable`1[T] elements, SkiaSharp.SKCanvas canvas, SkiaSharp.SKPaint stroke, SkiaSharp.SKPaint fill, System.Threading.CancellationToken token) [0x00010] in C:\projects\ffimageloading\source\FFImageLoading.Svg.Shared\SkSvg.cs:221 
  at FFImageLoading.Svg.Platform.SKSvg.Load (System.Xml.Linq.XDocument xdoc, System.Threading.CancellationToken token) [0x00417] in C:\projects\ffimageloading\source\FFImageLoading.Svg.Shared\SkSvg.cs:209 
  at FFImageLoading.Svg.Platform.SKSvg.Load (System.Xml.XmlReader reader, System.Threading.CancellationToken token) [0x00000] in C:\projects\ffimageloading\source\FFImageLoading.Svg.Shared\SkSvg.cs:100 
  at FFImageLoading.Svg.Platform.SKSvg.Load (System.IO.Stream stream, System.Threading.CancellationToken token) [0x00012] in C:\projects\ffimageloading\source\FFImageLoading.Svg.Shared\SkSvg.cs:94 
  at FFImageLoading.Svg.Platform.SvgDataResolver.Resolve (System.String identifier, FFImageLoading.Work.TaskParameter parameters, System.Threading.CancellationToken token) [0x0019d] in C:\projects\ffimageloading\source\FFImageLoading.Svg.Shared\SvgDataResolver.cs:232 
  at FFImageLoading.DataResolvers.WrappedDataResolver.Resolve (System.String identifier, FFImageLoading.Work.TaskParameter parameters, System.Threading.CancellationToken token) [0x0004e] in C:\projects\ffimageloading\source\FFImageLoading.Common\DataResolvers\WrappedDataResolver.cs:21 
  at FFImageLoading.Work.ImageLoaderTask`3[TDecoderContainer,TImageContainer,TImageView].RunAsync () [0x00300] in C:\projects\ffimageloading\source\FFImageLoading.Common\Work\ImageLoaderTask.cs:618
```
The same SVGs are displayed correctly on any other viewer apparently (tried Chrome, Safari, Inkscape).
The SVGs that I tried were exported from Figma, and if I'm not wrong from Illustrator too.
Just to make sure I used the recommended tools for optimizing the SVGs (svgo, svgomg) and none of them added the missing offset.

### :new: What is the new behavior (if this is a feature change)?
Now it supports implicit `offset="0"` when it's not specified in the stop. Example:
```
<linearGradient id="a" x1="5.29" x2="36.27" y1="5.29" y2="36.27" gradientUnits="userSpaceOnUse">
    <stop stop-color="#583ce5" />
    <stop offset=".34" stop-color="#a725b2" />
    <stop offset=".67" stop-color="#f4183f" />
    <stop offset="1" stop-color="#ffc34a" />
</linearGradient>
```

### :boom: Does this PR introduce a breaking change?
No

### :bug: Recommendations for testing
I tested it by editing the sample SVG removing the `offset="0"`, everything works normally after my change.

### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build - No, apparently master is broken before my changes.
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
