### PR TITLE
made ImageLoaderTask.TryLoadFromMemoryCacheAsync null safe

### DIFF
--- a/source/FFImageLoading.Common/Work/ImageLoaderTask.cs
+++ b/source/FFImageLoading.Common/Work/ImageLoaderTask.cs
@@ -477,7 +477,7 @@ namespace FFImageLoading.Work
 		private async Task<bool> TryLoadFromMemoryCacheAsync(string key, bool updateImageInformation, bool animated, bool isLoadingPlaceholder)
 		{
 			var found = MemoryCache.Get(key);
-			if (found?.Item1 != null)
+			if (found?.Item1 != null && found.Item2 != null)
 			{
 				try
 				{


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Fixes #1523

### :arrow_heading_down: What is the current behavior?

NullReferenceException thrown, when ImageLoaderTask.MemoryCache has entries with `null` values.

### :new: What is the new behavior (if this is a feature change)?

No NRE anymore, just reporting it as cache miss.

### :boom: Does this PR introduce a breaking change?

No.

### :bug: Recommendations for testing

None, as #1523 was reported by our production error reporting, and unfortunately no reproduction steps are available.

### :memo: Links to relevant issues/docs

None

### :thinking: Checklist before submitting

- [x] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
