### PR TITLE
fix:fix orientation of Android

### DIFF
--- a/source/FFImageLoading.Common/Helpers/Exif/ExifThumbnailDescriptor.cs
+++ b/source/FFImageLoading.Common/Helpers/Exif/ExifThumbnailDescriptor.cs
@@ -1,0 +1,9 @@
+﻿namespace FFImageLoading.Helpers.Exif
+{
+    internal class ExifThumbnailDescriptor : ExifDescriptorBase<ExifThumbnailDirectory>
+    {
+        public ExifThumbnailDescriptor(ExifThumbnailDirectory directory) : base(directory)
+        {
+        }
+    }
+}

--- a/source/FFImageLoading.Common/Helpers/Exif/ExifThumbnailDirectory.cs
+++ b/source/FFImageLoading.Common/Helpers/Exif/ExifThumbnailDirectory.cs
@@ -1,0 +1,32 @@
+﻿using System.Collections.Generic;
+
+namespace FFImageLoading.Helpers.Exif
+{
+    internal class ExifThumbnailDirectory : ExifDirectoryBase
+    {
+        /// <summary>The offset to thumbnail image bytes.</summary>
+        public const int TagThumbnailOffset = 0x0201;
+
+        /// <summary>The size of the thumbnail image data in bytes.</summary>
+        public const int TagThumbnailLength = 0x0202;
+
+        public ExifThumbnailDirectory()
+        {
+            SetDescriptor(new ExifThumbnailDescriptor(this));
+        }
+
+        private static readonly Dictionary<int, string> _tagNameMap = new Dictionary<int, string>();
+
+        static ExifThumbnailDirectory()
+        {
+            AddExifTagNames(_tagNameMap);
+        }
+
+        public override string Name => "Exif Thumbnail";
+
+        protected override bool TryGetTagName(int tagType, out string tagName)
+        {
+            return _tagNameMap.TryGetValue(tagType, out tagName);
+        }
+    }
+}

--- a/source/FFImageLoading.Common/Helpers/Exif/ExifTiffHandler.cs
+++ b/source/FFImageLoading.Common/Helpers/Exif/ExifTiffHandler.cs
@@ -74,6 +74,7 @@ namespace FFImageLoading.Helpers.Exif
             // UPDATE: In multipage TIFFs, the 'follower' IFD points to the next image in the set
             if (CurrentDirectory is ExifIfd0Directory)
             {
+                PushDirectory(new ExifThumbnailDirectory());
                 return true;
             }
 


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)
fix jpg/jepg image orientation of Android

### :arrow_heading_down: What is the current behavior?
When the Exif information of a  jpg/jepg image has both Exif IFD0 and Exif Thumbnail, and the image orientation of Exif IFD0 and Exif Thumbnail are inconsistent, the final picture orientation displayed on Android is not the actual orientation of the picture, but the orientation of the Thumbnail. 

test result before change：
![image](https://user-images.githubusercontent.com/32831595/123208116-77fdd080-d4f9-11eb-8b95-10f75150c99e.png)


### :new: What is the new behavior (if this is a feature change)?
The final picture orientation displayed on Android is the actual orientation of the picture, not the orientation of the Thumbnail. 

test result after change：
![image](https://user-images.githubusercontent.com/32831595/123208224-a54a7e80-d4f9-11eb-852a-eb46de32d5a0.png)

### :boom: Does this PR introduce a breaking change?
No.

### :bug: Recommendations for testing
Use images with different exif information for testing .

### :memo: Links to relevant issues/docs
https://github.com/luberda-molinet/FFImageLoading/issues/1537

### :thinking: Checklist before submitting

- [ ] All projects build
- [ ] Follows style guide lines 
- [ ] Relevant documentation was updated
- [ ] Rebased onto current develop
