### PR TITLE
Android / Blur Transformation: Fix leaked RenderScript objects

### DIFF
--- a/source/FFImageLoading.Transformations.Droid/BlurredTransformation.cs
+++ b/source/FFImageLoading.Transformations.Droid/BlurredTransformation.cs
@@ -71,19 +71,6 @@ namespace FFImageLoading.Transformations
                     rs.Destroy();
                     return output;
                 }
-
-                //Bitmap output = Bitmap.createBitmap(smallBitmap.getWidth(), smallBitmap.getHeight(), smallBitmap.getConfig());
-
-                //RenderScript rs = RenderScript.create(getContext());
-                //ScriptIntrinsicBlur script = ScriptIntrinsicBlur.create(rs, Element.U8_4(rs));
-                //Allocation inAlloc = Allocation.createFromBitmap(rs, smallBitmap, Allocation.MipmapControl.MIPMAP_NONE, Allocation.USAGE_GRAPHICS_TEXTURE);
-                //Allocation outAlloc = Allocation.createFromBitmap(rs, output);
-                //script.setRadius(BLUR_RADIUS);
-                //script.setInput(inAlloc);
-                //script.forEach(outAlloc);
-                //outAlloc.copyTo(output);
-
-                //rs.destroy();
             }
 
             return ToLegacyBlurred(source, context, (int)radius);

--- a/source/FFImageLoading.Transformations.Droid/BlurredTransformation.cs
+++ b/source/FFImageLoading.Transformations.Droid/BlurredTransformation.cs
@@ -64,6 +64,10 @@ namespace FFImageLoading.Transformations
                     script.ForEach(outAlloc);
                     outAlloc.CopyTo(output);
 
+                    // NOTE: Xamarin.Android Dispose() doesn't call 'destroy' on the allocations or scripts. Therefore, we must manually call it.
+                    outAlloc.Destroy();
+                    inAlloc.Destroy();
+                    script.Destroy();
                     rs.Destroy();
                     return output;
                 }


### PR DESCRIPTION
### :sparkles: What kind of change does this PR introduce? (Bug fix, feature, docs update...)

Manually invoke `Destroy()` on allocated RenderScript objects within the (Android) `BlurTransformation` class. Previously the assumption was that .NET `Dispose()` would call this for us, but this does not seem to be the case. 

By not doing this, the Android runtime complains about leaked resources.

```
[StrictMode] StrictMode policy violation: android.os.strictmode.LeakedClosableViolation: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
[StrictMode]    at android.os.StrictMode$AndroidCloseGuardReporter.report(StrictMode.java:1987)
[StrictMode]    at dalvik.system.CloseGuard.warnIfOpen(CloseGuard.java:345)
[StrictMode]    at android.renderscript.BaseObj.finalize(BaseObj.java:149)
[StrictMode]    at java.lang.Daemons$FinalizerDaemon.doFinalize(Daemons.java:291)
[StrictMode]    at java.lang.Daemons$FinalizerDaemon.runInternal(Daemons.java:278)
[StrictMode]    at java.lang.Daemons$Daemon.run(Daemons.java:139)
[StrictMode]    at java.lang.Thread.run(Thread.java:920)
[StrictMode] Caused by: java.lang.Throwable: Explicit termination method 'destroy' not called
[StrictMode]    at dalvik.system.CloseGuard.openWithCallSite(CloseGuard.java:295)
[StrictMode]    at dalvik.system.CloseGuard.open(CloseGuard.java:263)
[StrictMode]    at android.renderscript.Script.< init > (Script.java:349)
[StrictMode]    at android.renderscript.ScriptIntrinsic.< init > (ScriptIntrinsic.java:34)
[StrictMode]    at android.renderscript.ScriptIntrinsicBlur.< init > (ScriptIntrinsicBlur.java:33)
[StrictMode]    at android.renderscript.ScriptIntrinsicBlur.create(ScriptIntrinsicBlur.java:53)
[StrictMode] StrictMode policy violation: android.os.strictmode.LeakedClosableViolation: A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
[StrictMode]    at android.os.StrictMode$AndroidCloseGuardReporter.report(StrictMode.java:1987)
[StrictMode]    at dalvik.system.CloseGuard.warnIfOpen(CloseGuard.java:345)
[StrictMode]    at android.renderscript.BaseObj.finalize(BaseObj.java:149)
[StrictMode]    at android.renderscript.Allocation.finalize(Allocation.java:436)
[StrictMode]    at java.lang.Daemons$FinalizerDaemon.doFinalize(Daemons.java:291)
[StrictMode]    at java.lang.Daemons$FinalizerDaemon.runInternal(Daemons.java:278)
[StrictMode]    at java.lang.Daemons$Daemon.run(Daemons.java:139)
[StrictMode]    at java.lang.Thread.run(Thread.java:920)
[StrictMode] Caused by: java.lang.Throwable: Explicit termination method 'destroy' not called
[StrictMode]    at dalvik.system.CloseGuard.openWithCallSite(CloseGuard.java:295)
[StrictMode]    at dalvik.system.CloseGuard.open(CloseGuard.java:263)
[StrictMode]    at android.renderscript.Allocation.< init > (Allocation.java:425)
[StrictMode]    at android.renderscript.Allocation.< init > (Allocation.java:429)
[StrictMode]    at android.renderscript.Allocation.createFromBitmap(Allocation.java:2837)
```


**Note:** Also removed a duplicated copy of the Blur code that was commented out. Happy to revert this change if required. 

### :arrow_heading_down: What is the current behavior?


### :new: What is the new behavior (if this is a feature change)?


### :boom: Does this PR introduce a breaking change?


### :bug: Recommendations for testing

'StrictMode' was enabled by inserting the following to activity `OnCreate`

```
            StrictMode.SetVmPolicy(new StrictMode.VmPolicy.Builder(StrictMode.GetVmPolicy())
                                                          .DetectLeakedClosableObjects()
                                                          .Build());
```


### :memo: Links to relevant issues/docs


### :thinking: Checklist before submitting

- [ ] All projects build
- [x] Follows style guide lines 
- [ ] Relevant documentation was updated
- [x] Rebased onto current develop
